### PR TITLE
#4085_link_is_not_active

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -36,6 +36,7 @@ public final class ErrorMessage {
     public static final String LANGUAGE_NOT_FOUND_BY_ID = "The language does not exist by this id: ";
     public static final String USER_DEACTIVATION_REASON_IS_EMPTY = "The User deactivation reasons list is empty";
     public static final String USER_ALREADY_HAS_PASSWORD = "User already has password";
+    public static final String LINK_IS_NO_ACTIVE = "This link is no longer active";
 
     private ErrorMessage() {
     }

--- a/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
@@ -1,7 +1,6 @@
 package greencity.security.service;
 
 import greencity.constant.ErrorMessage;
-import greencity.dto.notification.NotificationDto;
 import greencity.entity.OwnSecurity;
 import greencity.entity.RestorePasswordEmail;
 import greencity.entity.User;
@@ -101,7 +100,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
     public void updatePasswordUsingToken(OwnRestoreDto form) {
         RestorePasswordEmail restorePasswordEmail = restorePasswordEmailRepo
             .findByToken(form.getToken())
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.TOKEN_FOR_RESTORE_IS_INVALID));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.LINK_IS_NO_ACTIVE));
         if (!form.getPassword().equals(form.getConfirmPassword())) {
             throw new BadRequestException(ErrorMessage.PASSWORDS_DO_NOT_MATCH);
         }
@@ -119,7 +118,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
         } else {
             log.info("Password restoration token of user with email " + restorePasswordEmail.getUser().getEmail()
                 + " has been expired. Token: " + form.getToken());
-            throw new UserActivationEmailTokenExpiredException(ErrorMessage.EMAIL_TOKEN_EXPIRED);
+            throw new UserActivationEmailTokenExpiredException(ErrorMessage.LINK_IS_NO_ACTIVE);
         }
         if (userStatus == UserStatus.CREATED) {
             restorePasswordEmail.getUser().setUserStatus(UserStatus.ACTIVATED);


### PR DESCRIPTION
[[Forgot password] A reset password link can be used for the second time after it was already successfully used #4085](https://github.com/ita-social-projects/GreenCity/issues/4085)
Send correct "errorMessage"