### PR TITLE
Fix bug when admin or employee save the permission for himself

### DIFF
--- a/service-api/pom.xml
+++ b/service-api/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <jjwt.version>0.9.1</jjwt.version>
         <passay.version>1.6.0</passay.version>
+        <apache.commons.version>4.4</apache.commons.version>
     </properties>
 
     <artifactId>service-api</artifactId>
@@ -108,6 +109,11 @@
             <artifactId>dao</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${apache.commons.version}</version>
         </dependency>
     </dependencies>
 

--- a/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,8 +44,12 @@ public class AuthorityServiceImpl implements AuthorityService {
         if (!employee.getRole().equals(Role.ROLE_UBS_EMPLOYEE)) {
             throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
-        List<Authority> list = authorityRepo.findAuthoritiesByNames(dto.getAuthorities());
-        employee.setAuthorities(list);
+
+        List<Authority> authorities = new ArrayList<>();
+        if (!dto.getAuthorities().isEmpty()) {
+            authorities = authorityRepo.findAuthoritiesByNames(dto.getAuthorities());
+        }
+        employee.setAuthorities(authorities);
         userRepo.save(employee);
     }
 

--- a/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,8 +44,12 @@ public class AuthorityServiceImpl implements AuthorityService {
         if (!employee.getRole().equals(Role.ROLE_UBS_EMPLOYEE)) {
             throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
-        List<Authority> list = authorityRepo.findAuthoritiesByNames(dto.getAuthorities());
-        employee.setAuthorities(list);
+
+        List<Authority> authorities = new ArrayList<>();
+        if(!dto.getAuthorities().isEmpty()) {
+            authorities = authorityRepo.findAuthoritiesByNames(dto.getAuthorities());
+        }
+        employee.setAuthorities(authorities);
         userRepo.save(employee);
     }
 

--- a/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/AuthorityServiceImpl.java
@@ -14,7 +14,7 @@ import greencity.repository.UserRepo;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
+import org.apache.commons.collections4.CollectionUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,7 +46,7 @@ public class AuthorityServiceImpl implements AuthorityService {
         }
 
         List<Authority> authorities = new ArrayList<>();
-        if (!dto.getAuthorities().isEmpty()) {
+        if (CollectionUtils.isNotEmpty(dto.getAuthorities())) {
             authorities = authorityRepo.findAuthoritiesByNames(dto.getAuthorities());
         }
         employee.setAuthorities(authorities);

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -156,6 +156,13 @@ public class ModelUtils {
             .build();
     }
 
+    public static UserEmployeeAuthorityDto getUserEmployeeWithNoAuthorityDto() {
+        return UserEmployeeAuthorityDto.builder()
+                .employeeEmail("taras@gmail.com")
+                .authorities(List.of("test"))
+                .build();
+    }
+
     public static Authority getAuthority() {
         List<User> list = new ArrayList<>();
         list.add(createUser());

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -158,9 +158,9 @@ public class ModelUtils {
 
     public static UserEmployeeAuthorityDto getUserEmployeeWithNoAuthorityDto() {
         return UserEmployeeAuthorityDto.builder()
-                .employeeEmail("taras@gmail.com")
-                .authorities(List.of("test"))
-                .build();
+            .employeeEmail("taras@gmail.com")
+            .authorities(Collections.emptyList())
+            .build();
     }
 
     public static Authority getAuthority() {

--- a/service/src/test/java/greencity/security/service/AuthorityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/AuthorityServiceImplTest.java
@@ -72,7 +72,7 @@ class AuthorityServiceImplTest {
         User employee = createEmployee();
         List<Authority> authority = List.of(getAuthority());
         List<String> authoritiesName = authority.stream().map(Authority::getName)
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
 
         when(userRepo.findByEmail("taras@gmail.com")).thenReturn(Optional.of(employee));
         when(authorityRepo.findAuthoritiesByNames(authoritiesName)).thenReturn(authority);

--- a/service/src/test/java/greencity/security/service/AuthorityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/AuthorityServiceImplTest.java
@@ -68,6 +68,21 @@ class AuthorityServiceImplTest {
     }
 
     @Test
+    void updateEmployeesWithEmptyAuthoritiesListTest() {
+        User employee = createEmployee();
+        List<Authority> authority = List.of(getAuthority());
+        List<String> authoritiesName = authority.stream().map(Authority::getName)
+                .collect(Collectors.toList());
+
+        when(userRepo.findByEmail("taras@gmail.com")).thenReturn(Optional.of(employee));
+        when(authorityRepo.findAuthoritiesByNames(authoritiesName)).thenReturn(authority);
+        employee.setAuthorities(authority);
+        authorityService.updateEmployeesAuthorities(getUserEmployeeWithNoAuthorityDto());
+
+        verify(userRepo).save(employee);
+    }
+
+    @Test
     void updateEmployeesAuthoritiesTestBadRequestException() {
         User employee = createEmployee();
         employee.setRole(Role.ROLE_USER);


### PR DESCRIPTION
# GreenCityUser PR Employee permission #5422
Fix the logic when the current admin sent a empty permission list

## Summary Of Changes
Has been changed impl class

## Issue Link
https://github.com/ita-social-projects/GreenCity/issues/5422


## Changed
* AuthorityServiceImpl
# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
