### PR TITLE
Fixed changing password for user not working

### DIFF
--- a/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
+++ b/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
@@ -154,7 +154,6 @@ class OwnSecurityControllerTest {
 
         String content = "{\n" +
             "  \"confirmPassword\": \"String123=\",\n" +
-            "  \"currentPassword\": \"String123=\",\n" +
             "  \"password\": \"String124=\"\n" +
             "}";
 

--- a/service-api/src/main/java/greencity/security/dto/ownsecurity/UpdatePasswordDto.java
+++ b/service-api/src/main/java/greencity/security/dto/ownsecurity/UpdatePasswordDto.java
@@ -15,9 +15,6 @@ import javax.validation.constraints.NotBlank;
 public class UpdatePasswordDto {
     @NotBlank
     @PasswordValidation
-    private String currentPassword;
-    @NotBlank
-    @PasswordValidation
     private String password;
 
     @NotBlank

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -342,9 +342,6 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         if (!updatePasswordDto.getPassword().equals(updatePasswordDto.getConfirmPassword())) {
             throw new PasswordsDoNotMatchesException(ErrorMessage.PASSWORDS_DO_NOT_MATCH);
         }
-        if (!passwordEncoder.matches(updatePasswordDto.getCurrentPassword(), user.getOwnSecurity().getPassword())) {
-            throw new WrongPasswordException(ErrorMessage.BAD_PASSWORD);
-        }
         updatePassword(updatePasswordDto.getPassword(), user.getId());
     }
 

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -1,7 +1,6 @@
 package greencity.security.service;
 
 import greencity.TestConst;
-import greencity.client.RestClient;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -121,7 +120,6 @@ class OwnSecurityServiceImplTest {
             .role(Role.ROLE_USER)
             .build();
         updatePasswordDto = UpdatePasswordDto.builder()
-            .currentPassword("password")
             .password("newPassword")
             .confirmPassword("newPassword")
             .build();
@@ -372,8 +370,6 @@ class OwnSecurityServiceImplTest {
     @Test
     void updateCurrentPasswordTest() {
         when(userService.findByEmail("test@gmail.com")).thenReturn(verifiedUser);
-        when(passwordEncoder.matches(updatePasswordDto.getCurrentPassword(),
-            verifiedUser.getOwnSecurity().getPassword())).thenReturn(true);
         when(passwordEncoder.encode(updatePasswordDto.getPassword())).thenReturn(updatePasswordDto.getPassword());
         ownSecurityService.updateCurrentPassword(updatePasswordDto, "test@gmail.com");
         verify(ownSecurityRepo).updatePassword(updatePasswordDto.getPassword(), 1L);
@@ -384,15 +380,6 @@ class OwnSecurityServiceImplTest {
         updatePasswordDto.setPassword("123");
         when(userService.findByEmail("test@gmail.com")).thenReturn(verifiedUser);
         assertThrows(PasswordsDoNotMatchesException.class,
-            () -> ownSecurityService.updateCurrentPassword(updatePasswordDto, "test@gmail.com"));
-    }
-
-    @Test
-    void updateCurrentPasswordPasswordsDoNotMatchTest() {
-        when(userService.findByEmail("test@gmail.com")).thenReturn(verifiedUser);
-        when(passwordEncoder.matches(updatePasswordDto.getCurrentPassword(),
-            verifiedUser.getOwnSecurity().getPassword())).thenReturn(false);
-        assertThrows(WrongPasswordException.class,
             () -> ownSecurityService.updateCurrentPassword(updatePasswordDto, "test@gmail.com"));
     }
 


### PR DESCRIPTION
## Summary Of Issue :
Error 500 when trying to change password using ownSecurity/changePassword endpoint because of not passing current password of user in request.

Issue Link
https://github.com/ita-social-projects/GreenCity/issues/5667

## Summary Of Changes 
1) Deleted currentPassoword field from UpdatePasswordDto.java
2) Deleted check if currentPassword is equal to current system user's password
3) Changed tests OwnSecurityControllerTest.java and OwnSecurityServiceImplTest.java

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers

Deleted currentPassword field from UpdatePasswordDto and removed check if current password matches current user's password