### PR TITLE
#5670 fix methods to get and change the user’s default language

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -135,6 +135,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/user/findFriendByName/**",
                 "/user/findByUuId",
                 "/user/findUuidByEmail",
+                "/user/lang",
                 "/user/createUbsRecord",
                 "/ownSecurity/password-status")
             .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
@@ -151,7 +152,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/ownSecurity/changePassword",
                 "/user/profile",
                 "/user/{id}/updateUserLastActivityTime/{date}",
-                "/user/{userId}/language/{languageId}",
+                "/user/language/{languageId}",
                 "/user/employee-email")
             .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
             .antMatchers(HttpMethod.PUT,

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -916,7 +916,8 @@ public class UserController {
     /**
      * Method for getting {@link String} user language.
      *
-     * @param id of the searched {@link UserVO}.
+     * @param userVO {@link UserVO} the current user that wants to get his profile
+     *               language
      * @return current user language {@link String}.
      * @author Vlad Pikhotskyi
      */
@@ -927,8 +928,8 @@ public class UserController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
     })
     @GetMapping("/lang")
-    public ResponseEntity<String> getUserLang(@RequestParam Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserLang(id));
+    public ResponseEntity<String> getUserLang(@ApiIgnore @CurrentUser UserVO userVO) {
+        return ResponseEntity.status(HttpStatus.OK).body(userVO.getLanguageVO().getCode());
     }
 
     /**
@@ -957,7 +958,8 @@ public class UserController {
     /**
      * Method that change user language.
      *
-     * @param userId     {@link Long } user id
+     * @param userVO     {@link UserVO} the current user that wants to change his
+     *                   profile language
      * @param languageId {@link Long} language id.
      */
     @ApiOperation(value = "Update user language")
@@ -966,10 +968,10 @@ public class UserController {
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
     })
-    @PutMapping("/{userId}/language/{languageId}")
-    public ResponseEntity<Object> setUserLanguage(@PathVariable @CurrentUserId Long userId,
+    @PutMapping("/language/{languageId}")
+    public ResponseEntity<Object> setUserLanguage(@ApiIgnore @CurrentUser UserVO userVO,
         @PathVariable Long languageId) {
-        userService.updateUserLanguage(userId, languageId);
+        userService.updateUserLanguage(userVO.getId(), languageId);
         return ResponseEntity.ok().build();
     }
 

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import greencity.TestConst;
 
 import static greencity.constant.AppConstant.AUTHORIZATION;
 
+import greencity.constant.AppConstant;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.PageableAdvancedDto;
 import greencity.dto.UpdateEmployeeAuthoritiesDto;
@@ -14,6 +15,7 @@ import greencity.dto.achievement.UserAchievementVO;
 import greencity.dto.achievement.UserVOAchievement;
 import greencity.dto.achievementcategory.AchievementCategoryVO;
 import greencity.dto.filter.FilterUserDto;
+import greencity.dto.language.LanguageVO;
 import greencity.dto.ubs.UbsTableCreationDto;
 import greencity.dto.user.UserEmployeeAuthorityDto;
 import greencity.dto.user.UserManagementUpdateDto;
@@ -635,21 +637,44 @@ class UserControllerTest {
 
     @Test
     void updateUserLanguageTest() throws Exception {
-        String accessToken = "accessToken";
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, accessToken);
-        mockMvc.perform(put(userLink + "/{userId}/language/{languageId}", 1, 1)
-            .headers(headers))
+        Principal principal = mock(Principal.class);
+        String languageCode = AppConstant.DEFAULT_LANGUAGE_CODE;
+        long userId = 1L;
+        UserVO userVO = UserVO.builder()
+            .id(userId)
+            .languageVO(LanguageVO.builder()
+                .id(2L)
+                .code(languageCode)
+                .build())
+            .build();
+
+        when(principal.getName()).thenReturn(TestConst.EMAIL);
+        when(userService.findByEmail(principal.getName())).thenReturn(userVO);
+
+        mockMvc.perform(put(userLink + "/language/{languageId}", 1)
+            .principal(principal))
             .andExpect(status().isOk());
-        verify(userService).updateUserLanguage(1L, 1L);
+
+        verify(userService).updateUserLanguage(userId, 1L);
     }
 
     @Test
     void getUserLang() throws Exception {
+        Principal principal = mock(Principal.class);
+        String languageCode = AppConstant.DEFAULT_LANGUAGE_CODE;
+        UserVO userVO = ModelUtils.TEST_USER_VO;
+        userVO.setLanguageVO(LanguageVO.builder()
+            .id(2L)
+            .code(languageCode)
+            .build());
+
+        when(principal.getName()).thenReturn(TestConst.EMAIL);
+        when(userService.findByEmail(principal.getName())).thenReturn(userVO);
+
         this.mockMvc.perform(get(userLink + "/lang" + "?id=1")
-            .contentType(MediaType.APPLICATION_JSON))
+            .principal(principal))
+            .andExpect(content().string(languageCode))
             .andExpect(status().isOk());
-        verify(userService).getUserLang(1L);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/service/UserService.java
+++ b/service-api/src/main/java/greencity/service/UserService.java
@@ -544,15 +544,6 @@ public interface UserService {
     List<String> getDeactivationReason(Long id, String adminLang);
 
     /**
-     * Method for getting {@link String} user language.
-     *
-     * @param id of the searched {@link UserVO}.
-     * @return current user language {@link String}.
-     * @author Vlad Pikhotskyi
-     */
-    String getUserLang(Long id);
-
-    /**
      * Method that update user language column.
      *
      * @param userId     {@link Long} -current user's id.

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -961,16 +961,6 @@ public class UserServiceImpl implements UserService {
      * {@inheritDoc}
      */
     @Override
-    public String getUserLang(Long id) {
-        User user = userRepo.findById(id)
-            .orElseThrow(() -> new WrongIdException(ErrorMessage.USER_NOT_FOUND_BY_ID + id));
-        return user.getLanguage().getCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public List<String> getDeactivationReason(Long id, String adminLang) {
         UserDeactivationReason userReason = userDeactivationRepo.getLastDeactivationReasons(id)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_DEACTIVATION_REASON_IS_EMPTY));

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1036,17 +1036,6 @@ class UserServiceImplTest {
     }
 
     @Test
-    void getUserLang() {
-        User user = ModelUtils.getUser();
-        user.setLanguage(Language.builder()
-            .id(1L)
-            .code("en")
-            .build());
-        when(userRepo.findById(1L)).thenReturn(Optional.of(user));
-        assertEquals(user.getLanguage().getCode(), userService.getUserLang(1L));
-    }
-
-    @Test
     void getDeactivationReason() {
         List<String> test1 = List.of();
         User user = ModelUtils.getUser();


### PR DESCRIPTION
## Summary Of Issue :
Need to fix methods getUserLang and setUserLanguage of UserController. Both of these methods allow any user to retrieve and change the profile language of any other user.


**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5670

## Summary Of Changes :
1) updated getUserLang and setUserLanguage, now they are avaliable only for registered users
2) removed unnecessary method getUserLang of in UserServiceIml and test for it
3) updated PUT "/user/language/{languageId}" and added GET "/user/lang" endpoints
4) refactored old tests 


## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers
