### PR TITLE
#5297 fixed issue allowing unverified users to change their password

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -42,6 +42,7 @@ public final class ErrorMessage {
     public static final String USER_CREATED = "User is not activated";
     public static final String USER_CANNOT_HAVE_SUCH_AUTHORITIES = "Not valid authorities for this user";
     public static final String USER_DOES_NOT_LOGIN = "User has not login in the system by this email: ";
+    public static final String USER_EMAIL_IS_NOT_VERIFIED = "The user's email address has not been verified.";
 
     private ErrorMessage() {
     }

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -369,6 +369,11 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
     @Transactional
     public void updateCurrentPassword(UpdatePasswordDto updatePasswordDto, String email) {
         UserVO user = userService.findByEmail(email);
+
+        if (user.getUserStatus() != UserStatus.ACTIVATED) {
+            throw new EmailNotVerified(ErrorMessage.USER_EMAIL_IS_NOT_VERIFIED);
+        }
+
         if (!updatePasswordDto.getPassword().equals(updatePasswordDto.getConfirmPassword())) {
             throw new PasswordsDoNotMatchesException(ErrorMessage.PASSWORDS_DO_NOT_MATCH);
         }

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -409,6 +409,19 @@ class OwnSecurityServiceImplTest {
     }
 
     @Test
+    void updateCurrentPasswordEmailNotVerifiedTest() {
+        updatePasswordDto.setPassword("123");
+
+        UserVO user = ModelUtils.getUserVO();
+        user.setUserStatus(UserStatus.CREATED);
+
+        when(userService.findByEmail("test@gmail.com")).thenReturn(user);
+
+        assertThrows(EmailNotVerified.class,
+            () -> ownSecurityService.updateCurrentPassword(updatePasswordDto, "test@gmail.com"));
+    }
+
+    @Test
     void managementRegisterUserTest() {
         User user = ModelUtils.getUser();
         user.setUserStatus(UserStatus.BLOCKED);


### PR DESCRIPTION
Oleh Vatuliak
https://github.com/ita-social-projects/GreenCity/issues/5297

## Summary of issue
The issue allows unverified users to change their password before verifying their email address.

## Summary of change
Added check of email verification before password update.