### PR TITLE
[GreenCity User] - A reset password link can be used for the second time after it was already successfully used

### DIFF
--- a/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
@@ -112,6 +112,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
                 user.getName(), form.getIsUbs());
             applicationEventPublisher.publishEvent(
                 new UpdatePasswordEvent(this, form.getPassword(), restorePasswordEmail.getUser().getId()));
+            user.setRestorePasswordEmail(null);
             restorePasswordEmailRepo.delete(restorePasswordEmail);
             log.info("User with email " + restorePasswordEmail.getUser().getEmail()
                 + " has successfully restored the password using token " + form.getToken());


### PR DESCRIPTION
## Summary Of Issue :
Password change link can be used an infinite number of times

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/4085

## Summary Of Changes :
- added deleting user field restorePasswordEmail

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers