### PR TITLE
[Friends] - Find friends - user see already friend on find friends page #5828

### DIFF
--- a/dao/src/main/java/greencity/repository/UserRepo.java
+++ b/dao/src/main/java/greencity/repository/UserRepo.java
@@ -399,8 +399,9 @@ public interface UserRepo extends JpaRepository<User, Long>, JpaSpecificationExe
      * @param userId   {@link Long} -current user's id.
      * @return {@link User}.
      */
-    @Query(nativeQuery = true, value = "SELECT * FROM users WHERE users.id <> :userId AND users.id NOT IN"
-        + "(SELECT friend_id FROM users_friends WHERE user_id = :userId)")
+    @Query(nativeQuery = true, value = "SELECT * FROM users WHERE users.id <> :userId AND users.id NOT IN "
+        + "((SELECT user_id FROM users_friends WHERE friend_id = :userId) "
+        + "UNION (SELECT friend_id FROM users_friends WHERE user_id = :userId))")
     Page<User> getAllUsersExceptMainUserAndFriends(Pageable pageable, @Param("userId") Long userId);
 
     /**

--- a/dao/src/test/java/greencity/repository/UserRepoTest.java
+++ b/dao/src/test/java/greencity/repository/UserRepoTest.java
@@ -294,4 +294,20 @@ class UserRepoTest {
         List<UsersFriendDto> friendDtos = userRepo.findAnyRecommendedFriends(1L);
         assertEquals(1, friendDtos.size());
     }
+
+    @Test
+    void getAllUsersExceptMainUserAndFriendsTest() {
+        Pageable pageable = PageRequest.of(0, 2);
+        User user = userRepo.findByEmail("test9@email.com").get();
+        List<User> users = List.of(user);
+        Page<User> actual = new PageImpl<>(users, pageable, users.size());
+        Page<User> expected = userRepo.getAllUsersExceptMainUserAndFriends(pageable, 1L);
+        List<Long> actualIds = actual.getContent().stream().map(User::getId)
+            .collect(Collectors.toList());
+        List<Long> expectedIds = expected.getContent().stream().map(User::getId)
+            .collect(Collectors.toList());
+
+        assertEquals(1, expected.getContent().size());
+        assertEquals(expectedIds, actualIds);
+    }
 }

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -1090,17 +1090,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public PageableDto<UserAllFriendsDto> findNewFriendByName(String name, Pageable page, Long id) {
         Page<User> ourUsersList = userRepo.findUsersByName(name, page, id);
-        List<UserAllFriendsDto> friendDtos = modelMapper.map(ourUsersList.getContent(),
-            new TypeToken<List<UserAllFriendsDto>>() {
-            }.getType());
-
-        friendDtos.stream().forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), id)));
-
-        return new PageableDto<>(
-            allUsersMutualFriendsRecommendedOrRequest(id, friendDtos),
-            ourUsersList.getTotalElements(),
-            ourUsersList.getPageable().getPageNumber(),
-            ourUsersList.getTotalPages());
+        return getUserAllFriendsDtoPageableDto(id, ourUsersList);
     }
 
     /**
@@ -1109,17 +1099,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public PageableDto<UserAllFriendsDto> findUserByName(String name, Pageable page, Long id) {
         Page<User> ourUsersList = userRepo.findAllUsersByName(name, page, id);
-        List<UserAllFriendsDto> friendDtos = modelMapper.map(ourUsersList.getContent(),
-            new TypeToken<List<UserAllFriendsDto>>() {
-            }.getType());
-
-        friendDtos.stream().forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), id)));
-
-        return new PageableDto<>(
-            allUsersMutualFriendsRecommendedOrRequest(id, friendDtos),
-            ourUsersList.getTotalElements(),
-            ourUsersList.getPageable().getPageNumber(),
-            ourUsersList.getTotalPages());
+        return getUserAllFriendsDtoPageableDto(id, ourUsersList);
     }
 
     /**
@@ -1128,17 +1108,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public PageableDto<UserAllFriendsDto> findFriendByName(String name, Pageable page, Long id) {
         Page<User> ourUsersList = userRepo.findFriendsByName(name, page, id);
-        List<UserAllFriendsDto> friendDtos = modelMapper.map(ourUsersList.getContent(),
-            new TypeToken<List<UserAllFriendsDto>>() {
-            }.getType());
-
-        friendDtos.stream().forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), id)));
-
-        return new PageableDto<>(
-            allUsersMutualFriendsRecommendedOrRequest(id, friendDtos),
-            ourUsersList.getTotalElements(),
-            ourUsersList.getPageable().getPageNumber(),
-            ourUsersList.getTotalPages());
+        return getUserAllFriendsDtoPageableDto(id, ourUsersList);
     }
 
     /**
@@ -1219,11 +1189,15 @@ public class UserServiceImpl implements UserService {
     @Override
     public PageableDto<UserAllFriendsDto> findAllUsersExceptMainUserAndUsersFriend(Pageable pageable, Long userId) {
         Page<User> allUsers = userRepo.getAllUsersExceptMainUserAndFriends(pageable, userId);
+        return getUserAllFriendsDtoPageableDto(userId, allUsers);
+    }
+
+    private PageableDto<UserAllFriendsDto> getUserAllFriendsDtoPageableDto(Long userId, Page<User> allUsers) {
         List<UserAllFriendsDto> allFriends = modelMapper
             .map(allUsers.getContent(),
                 new TypeToken<List<UserAllFriendsDto>>() {
                 }.getType());
-        allFriends.stream().forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), userId)));
+        allFriends.forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), userId)));
         return new PageableDto<>(
             allUsersMutualFriendsRecommendedOrRequest(userId, allFriends),
             allUsers.getTotalElements(),

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1291,4 +1291,35 @@ class UserServiceImplTest {
             Arguments.of("444e66e8-8daa-4cb0-8269-a8d856e7dd15", Optional.of(getUser()), true),
             Arguments.of("uuid", Optional.empty(), false));
     }
+
+    @Test
+    void findAllUsersExceptMainUserAndUsersFriendTest() {
+        List<User> userList = Collections.singletonList(user);
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        Page<User> page = new PageImpl<>(userList, pageRequest, userList.size());
+        List<UserAllFriendsDto> dtoList =
+            Collections.singletonList(
+                new UserAllFriendsDto(
+                    1L, "test", "test", 20.0, 1L, "test", "aa",
+                    FriendsChatDto.builder()
+                        .chatId(1L)
+                        .chatExists(true)
+                        .build()));
+
+        when(userRepo.getAllUsersExceptMainUserAndFriends(pageRequest, userId)).thenReturn(page);
+        when(modelMapper.map(userList, new TypeToken<List<UserAllFriendsDto>>() {
+        }.getType())).thenReturn(dtoList);
+        when(restClient.chatBetweenTwo(anyLong(), anyLong())).thenReturn(any(FriendsChatDto.class));
+        when(userRepo.getAllUserFriends(1L)).thenReturn(userList);
+        when(userRepo.getAllUserFriends(1L)).thenReturn(userList);
+
+        userService.findAllUsersExceptMainUserAndUsersFriend(pageRequest, 1L);
+
+        verify(userRepo).getAllUsersExceptMainUserAndFriends(pageRequest, userId);
+        verify(modelMapper).map(userList, new TypeToken<List<UserAllFriendsDto>>() {
+        }.getType());
+        verify(restClient).chatBetweenTwo(anyLong(), anyLong());
+        verify(userRepo, times(2)).getAllUserFriends(1L);
+    }
+
 }


### PR DESCRIPTION
## Summary Of  Issue :fire:
User see on find friends page users that is already his/her friends

## Issue Link :clipboard:
https://github.com/ita-social-projects/GreenCity/issues/5828

## Changed

- getAllUsersExceptMainUserAndFriends() in dao/src/main/java/greencity/repository/UserRepo.java
- findNewFriendByName(), findUserByName(),  findFriendByName() and findAllUsersExceptMainUserAndUsersFriend() in service/src/main/java/greencity/service/UserServiceImpl.java

## Added
New test methods to dao/src/test/java/greencity/repository/UserRepoTest.java and service/src/test/java/greencity/service/UserServiceImplTest.java

## Test
Tested by /user/{userId}/findAll/friendsWithoutExist/ endpoint in swagger http://localhost:8060/swagger-ui.html#/