### PR TITLE
[GreenCityUser] - Isn't able to reject friend request

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -148,7 +148,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/user/shopping-list-items",
                 "/user/{userId}/habit",
                 "/user/{userId}/userFriend/{friendId}",
-                "/user/{userId}/declineFriend/{friendId}",
                 "/user/{userId}/acceptFriend/{friendId}",
                 "/ownSecurity/set-password")
             .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
@@ -177,6 +176,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers(HttpMethod.DELETE,
                 "/user/shopping-list-items/user-shopping-list-items",
                 "/user/shopping-list-items",
+                "/user/{userId}/declineFriend/{friendId}",
                 "/user/{userId}/userFriend/{friendId}")
             .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
             .antMatchers(HttpMethod.GET,


### PR DESCRIPTION
## Summary Of  Issue
User isn't able to reject friend request by clicking 'Decline' button

## Issue Link :clipboard:
https://github.com/ita-social-projects/GreenCity/issues/5594

## Changed
Fxed error 405 when friend request was declined

## Test
Tested by/{userId}/declineFriend/{friendId} endpoint in swagger http://localhost:8060/swagger-ui.html#/