### PR TITLE
[User's personal cabinet] fixed bug with getPositionsAndRelatedAuthorities

### DIFF
--- a/dao/src/main/java/greencity/repository/AuthorityRepo.java
+++ b/dao/src/main/java/greencity/repository/AuthorityRepo.java
@@ -32,7 +32,9 @@ public interface AuthorityRepo extends JpaRepository<Authority, Long> {
      * @param name - list of positions name.
      * @return list of authorities.
      */
-    @Query(value = "SELECT DISTINCT au FROM Authority au LEFT JOIN au.positions pos WHERE pos.name IN (:name)")
+    @Query(
+        value = "SELECT DISTINCT au FROM Authority au LEFT JOIN au.positions pos "
+            + "WHERE pos.name IN (:name) or pos.nameEn IN (:name)")
     List<Authority> findAuthoritiesByPositions(List<String> name);
 
     /**

--- a/service/src/main/java/greencity/security/service/PositionServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PositionServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @AllArgsConstructor
@@ -31,9 +32,8 @@ public class PositionServiceImpl implements PositionService {
         List<Authority> authorities = authorityRepo
             .findAuthoritiesByPositions(user.getPositions()
                 .stream()
-                .map(Position::getName)
+                .flatMap(position -> Stream.of(position.getName(), position.getNameEn()))
                 .collect(Collectors.toList()));
-
         return PositionAuthoritiesDto.builder()
             .positionId(user.getPositions().stream().map(Position::getId).collect(Collectors.toList()))
             .authorities(authorities.stream().map(Authority::getName).collect(Collectors.toList()))

--- a/service/src/main/java/greencity/security/service/PositionServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PositionServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -33,10 +34,13 @@ public class PositionServiceImpl implements PositionService {
             .findAuthoritiesByPositions(user.getPositions()
                 .stream()
                 .flatMap(position -> Stream.of(position.getName(), position.getNameEn()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
         return PositionAuthoritiesDto.builder()
             .positionId(user.getPositions().stream().map(Position::getId).collect(Collectors.toList()))
-            .authorities(authorities.stream().map(Authority::getName).collect(Collectors.toList()))
+            .authorities(authorities.stream()
+                .map(Authority::getName)
+                .collect(Collectors.toList()))
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -616,9 +616,43 @@ public class ModelUtils {
     public static User getEmployeeWithPositionsAndRelatedAuthorities() {
         return User.builder()
             .positions(List.of(Position.builder()
-                .id(1L)
-                .name("Admin")
+                .id(1L).name("Адмін")
                 .nameEn("Admin")
+                .build()))
+            .authorities(List.of(Authority.builder()
+                .name("Auth")
+                .build()))
+            .build();
+    }
+
+    public static User getEmployeeWithPositionsAndRelatedAuthorities_UA() {
+        return User.builder()
+            .positions(List.of(Position.builder()
+                .id(1L)
+                .name("Адмін")
+                .build()))
+            .authorities(List.of(Authority.builder()
+                .name("Auth")
+                .build()))
+            .build();
+    }
+
+    public static User getEmployeeWithPositionsAndRelatedAuthorities_EN() {
+        return User.builder()
+            .positions(List.of(Position.builder()
+                .id(1L)
+                .nameEn("Admin")
+                .build()))
+            .authorities(List.of(Authority.builder()
+                .name("Auth")
+                .build()))
+            .build();
+    }
+
+    public static User getEmployeeWithPositionsAndRelatedAuthorities_Empty() {
+        return User.builder()
+            .positions(List.of(Position.builder()
+                .id(1L)
                 .build()))
             .authorities(List.of(Authority.builder()
                 .name("Auth")

--- a/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
@@ -18,13 +18,11 @@ import org.mockito.quality.Strictness;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static greencity.ModelUtils.TEST_EMAIL;
-import static greencity.ModelUtils.createEmployee;
-import static greencity.ModelUtils.getEmployeeWithPositionsAndRelatedAuthorities;
-import static greencity.ModelUtils.getPositionAuthoritiesDto;
+import static greencity.ModelUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
@@ -59,6 +57,36 @@ class PositionServiceImplTest {
         var expected = getPositionAuthoritiesDto();
 
         when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
+        when(authorityRepo.findAuthoritiesByPositions(List.of("Адмін", "Admin")))
+            .thenReturn(List.of(Authority.builder().name("Auth").build()));
+
+        assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
+
+        verify(userRepo).findByEmail(TEST_EMAIL);
+        verify(authorityRepo).findAuthoritiesByPositions(List.of("Адмін", "Admin"));
+    }
+
+    @Test
+    void getPositionsAndRelatedAuthoritiesTest_UA() {
+        User employee = getEmployeeWithPositionsAndRelatedAuthorities_UA();
+        var expected = getPositionAuthoritiesDto();
+
+        when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
+        when(authorityRepo.findAuthoritiesByPositions(List.of("Адмін")))
+            .thenReturn(List.of(Authority.builder().name("Auth").build()));
+
+        assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
+
+        verify(userRepo).findByEmail(TEST_EMAIL);
+        verify(authorityRepo).findAuthoritiesByPositions(List.of("Адмін"));
+    }
+
+    @Test
+    void getPositionsAndRelatedAuthoritiesTest_EN() {
+        User employee = getEmployeeWithPositionsAndRelatedAuthorities_EN();
+        var expected = getPositionAuthoritiesDto();
+
+        when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
         when(authorityRepo.findAuthoritiesByPositions(List.of("Admin")))
             .thenReturn(List.of(Authority.builder().name("Auth").build()));
 
@@ -66,6 +94,22 @@ class PositionServiceImplTest {
 
         verify(userRepo).findByEmail(TEST_EMAIL);
         verify(authorityRepo).findAuthoritiesByPositions(List.of("Admin"));
+    }
+
+    @Test
+    void getPositionsAndRelatedAuthoritiesTest_BothNull() {
+        User employee = getEmployeeWithPositionsAndRelatedAuthorities_Empty();
+
+        var expected = getPositionAuthoritiesDto();
+        expected.setAuthorities(Collections.emptyList());
+        when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
+        when(authorityRepo.findAuthoritiesByPositions(Collections.emptyList()))
+            .thenReturn(Collections.emptyList());
+
+        assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
+
+        verify(userRepo).findByEmail(TEST_EMAIL);
+        verify(authorityRepo).findAuthoritiesByPositions(Collections.emptyList());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUser PR
[[User's personal cabinet] Authority doesn't set](https://github.com/ita-social-projects/GreenCity/issues/6135)

## Summary Of Changes :fire:
Added to position new field nameEn.

## Added
Added to method to check if English name of position correctly check.

## Changed
Method in user repo that return list of authorities.(findAuthoritiesByPositions)


# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers