### PR TITLE
Fixed bug with method getPositionsAndRelatedAuthorities

### DIFF
--- a/service/src/main/java/greencity/security/service/PositionServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PositionServiceImpl.java
@@ -30,15 +30,9 @@ public class PositionServiceImpl implements PositionService {
     public PositionAuthoritiesDto getPositionsAndRelatedAuthorities(String email) {
         var user = userRepo.findByEmail(email)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL));
-        List<Authority> authorities = authorityRepo
-            .findAuthoritiesByPositions(user.getPositions()
-                .stream()
-                .flatMap(position -> Stream.of(position.getName(), position.getNameEn()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList()));
         return PositionAuthoritiesDto.builder()
             .positionId(user.getPositions().stream().map(Position::getId).collect(Collectors.toList()))
-            .authorities(authorities.stream()
+            .authorities(user.getAuthorities().stream()
                 .map(Authority::getName)
                 .collect(Collectors.toList()))
             .build();

--- a/service/src/main/java/greencity/security/service/PositionServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PositionServiceImpl.java
@@ -15,9 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @AllArgsConstructor

--- a/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
@@ -57,49 +57,16 @@ class PositionServiceImplTest {
         var expected = getPositionAuthoritiesDto();
 
         when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
-        when(authorityRepo.findAuthoritiesByPositions(List.of("Адмін", "Admin")))
-            .thenReturn(List.of(Authority.builder().name("Auth").build()));
 
         assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
 
         verify(userRepo).findByEmail(TEST_EMAIL);
-        verify(authorityRepo).findAuthoritiesByPositions(List.of("Адмін", "Admin"));
     }
 
     @Test
-    void getPositionsAndRelatedAuthoritiesTest_UA() {
-        User employee = getEmployeeWithPositionsAndRelatedAuthorities_UA();
-        var expected = getPositionAuthoritiesDto();
-
-        when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
-        when(authorityRepo.findAuthoritiesByPositions(List.of("Адмін")))
-            .thenReturn(List.of(Authority.builder().name("Auth").build()));
-
-        assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
-
-        verify(userRepo).findByEmail(TEST_EMAIL);
-        verify(authorityRepo).findAuthoritiesByPositions(List.of("Адмін"));
-    }
-
-    @Test
-    void getPositionsAndRelatedAuthoritiesTest_EN() {
-        User employee = getEmployeeWithPositionsAndRelatedAuthorities_EN();
-        var expected = getPositionAuthoritiesDto();
-
-        when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
-        when(authorityRepo.findAuthoritiesByPositions(List.of("Admin")))
-            .thenReturn(List.of(Authority.builder().name("Auth").build()));
-
-        assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
-
-        verify(userRepo).findByEmail(TEST_EMAIL);
-        verify(authorityRepo).findAuthoritiesByPositions(List.of("Admin"));
-    }
-
-    @Test
-    void getPositionsAndRelatedAuthoritiesTest_BothNull() {
+    void getPositionsAndRelatedAuthoritiesTest_AuthorotiesListEmpty() {
         User employee = getEmployeeWithPositionsAndRelatedAuthorities_Empty();
-
+        employee.setAuthorities(Collections.emptyList());
         var expected = getPositionAuthoritiesDto();
         expected.setAuthorities(Collections.emptyList());
         when(userRepo.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -109,7 +76,6 @@ class PositionServiceImplTest {
         assertEquals(expected, positionService.getPositionsAndRelatedAuthorities(TEST_EMAIL));
 
         verify(userRepo).findByEmail(TEST_EMAIL);
-        verify(authorityRepo).findAuthoritiesByPositions(Collections.emptyList());
     }
 
     @Test

--- a/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/PositionServiceImplTest.java
@@ -1,6 +1,5 @@
 package greencity.security.service;
 
-import greencity.entity.Authority;
 import greencity.entity.User;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;


### PR DESCRIPTION
# GreenCityUser PR
[[Admin Cabinet] Dont get real authorities of user #6205](https://github.com/ita-social-projects/GreenCity/issues/6205)

## Summary Of Changes :fire:
Fixed bug with method getPositionsAndRelatedAuthorities


## Changed
Method getPositionsAndRelatedAuthorities. 
We didn't need to find Authorities according to Positions, we needed to find the Authorities that user have.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers