### PR TITLE
[API] 2 identical end-points #6324

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -478,40 +478,6 @@ public class UserController {
     }
 
     /**
-     * Method find user by principal.
-     *
-     * @return {@link ResponseEntity}.
-     * @author Orest Mamchuk
-     */
-    @ApiOperation(value = "Find current user by principal")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-    })
-    @GetMapping("/findByEmail")
-    public ResponseEntity<UserVO> findByEmail(@RequestParam String email) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findByEmail(email));
-    }
-
-    /**
-     * Get {@link UserVO} by id.
-     *
-     * @return {@link UserUpdateDto}.
-     * @author Orest Mamchuk
-     */
-    @ApiOperation(value = "Get User by id")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-    })
-    @GetMapping("/findById")
-    public ResponseEntity<UserVO> findById(@RequestParam Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findById(id));
-    }
-
-    /**
      * Method that allow you to find {@link UserVO} by Id.
      *
      * @return {@link UserUpdateDto}.

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -48,8 +48,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -404,31 +402,6 @@ class UserControllerTest {
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
         verify(userService).search(pageable, userViewDto);
-    }
-
-    @Test
-    void findByEmailTest() throws Exception {
-        UserVO userVO = ModelUtils.getUserVO();
-        when(userService.findByEmail(TestConst.EMAIL)).thenReturn(userVO);
-        mockMvc.perform(get(userLink + "/findByEmail")
-            .param("email", TestConst.EMAIL))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").value(1L))
-            .andExpect(jsonPath("$.name").value(TestConst.NAME))
-            .andExpect(jsonPath("$.email").value(TestConst.EMAIL));
-    }
-
-    @Test
-    void findByIdTest() throws Exception {
-        UserVO userVO = ModelUtils.getUserVO();
-        when(userService.findById(1L)).thenReturn(userVO);
-        mockMvc.perform(get(userLink + "/findById")
-            .param("id", "1"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType("application/json;charset=UTF-8"))
-            .andExpect(jsonPath("$.id").value(1L))
-            .andExpect(jsonPath("$.name").value(TestConst.NAME))
-            .andExpect(jsonPath("$.email").value(TestConst.EMAIL));
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUser PR
https://github.com/ita-social-projects/GreenCity/issues/6324

## Summary Of Changes :fire:
Endpoints GET [/user/findByEmail] and GET [/user/findById] are no longer used so they have been removed.

## Deleted
* Deleted two unused endpoints: GET [/user/findByEmail] and GET [/user/findById]

## How to test :clipboard:
It can be tests via swagger, such endpoints are not exist.
# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
