### PR TITLE
Update of profile statistics to add amount of events published by user

### DIFF
--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -252,4 +252,19 @@ public class RestClient {
             }
         };
     }
+
+    /**
+     * Method for getting amount of published events by {@link UserVO} id.
+     *
+     * @param userId of {@link UserVO}
+     * @return {@link Long} count of published by user events.
+     *
+     * @author Olena Sotnik
+     */
+    public Long findAmountOfEventsPublishedByUser(Long userId) {
+        HttpEntity<String> entity = new HttpEntity<>(setHeader());
+        return restTemplate.exchange(greenCityServerAddress
+            + RestTemplateLinks.EVENTS_PUBLISHED_BY_USER_COUNT + RestTemplateLinks.USER_ID + userId,
+            HttpMethod.GET, entity, Long.class).getBody();
+    }
 }

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -254,14 +254,15 @@ public class RestClient {
     }
 
     /**
-     * Method for getting amount of published events by {@link UserVO} id.
+     * Method for getting amount of organized and attended events by {@link UserVO}
+     * id.
      *
      * @param userId of {@link UserVO}
-     * @return {@link Long} count of published by user events.
+     * @return {@link Long} count of organized and attended by user events.
      *
      * @author Olena Sotnik
      */
-    public Long findAmountOfEventsPublishedByUser(Long userId) {
+    public Long findAmountOfEventsOrganizedAndAttendedByUser(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityServerAddress
             + RestTemplateLinks.EVENTS_PUBLISHED_BY_USER_COUNT + RestTemplateLinks.USER_ID + userId,

--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -265,7 +265,7 @@ public class RestClient {
     public Long findAmountOfEventsOrganizedAndAttendedByUser(Long userId) {
         HttpEntity<String> entity = new HttpEntity<>(setHeader());
         return restTemplate.exchange(greenCityServerAddress
-            + RestTemplateLinks.EVENTS_PUBLISHED_BY_USER_COUNT + RestTemplateLinks.USER_ID + userId,
+            + RestTemplateLinks.EVENTS_ORGANIZED_OR_ATTENDED_BY_USER_COUNT + RestTemplateLinks.USER_ID + userId,
             HttpMethod.GET, entity, Long.class).getBody();
     }
 }

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -21,7 +21,7 @@ public class RestTemplateLinks {
     public static final Object CALCULATE_ACHIEVEMENT_SOCIAL_NETWORK = "&socialNetwork=";
     public static final String CALCULATE_ACHIEVEMENT_SIZE = "&size=";
     public static final String UBS_USER_PROFILE = "/ubs/userProfile";
-    public static final String EVENTS_PUBLISHED_BY_USER_COUNT = "/events/published/count";
+    public static final String EVENTS_PUBLISHED_BY_USER_COUNT = "/events/userEvents/count";
 
     private RestTemplateLinks() {
     }

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -21,7 +21,7 @@ public class RestTemplateLinks {
     public static final Object CALCULATE_ACHIEVEMENT_SOCIAL_NETWORK = "&socialNetwork=";
     public static final String CALCULATE_ACHIEVEMENT_SIZE = "&size=";
     public static final String UBS_USER_PROFILE = "/ubs/userProfile";
-    public static final String EVENTS_PUBLISHED_BY_USER_COUNT = "/events/userEvents/count";
+    public static final String EVENTS_ORGANIZED_OR_ATTENDED_BY_USER_COUNT = "/events/userEvents/count";
 
     private RestTemplateLinks() {
     }

--- a/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
+++ b/service-api/src/main/java/greencity/constant/RestTemplateLinks.java
@@ -21,6 +21,7 @@ public class RestTemplateLinks {
     public static final Object CALCULATE_ACHIEVEMENT_SOCIAL_NETWORK = "&socialNetwork=";
     public static final String CALCULATE_ACHIEVEMENT_SIZE = "&size=";
     public static final String UBS_USER_PROFILE = "/ubs/userProfile";
+    public static final String EVENTS_PUBLISHED_BY_USER_COUNT = "/events/published/count";
 
     private RestTemplateLinks() {
     }

--- a/service-api/src/main/java/greencity/dto/user/UserProfileStatisticsDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileStatisticsDto.java
@@ -10,8 +10,7 @@ import lombok.*;
 @EqualsAndHashCode
 public class UserProfileStatisticsDto {
     private Long amountHabitsInProgress;
-
     private Long amountHabitsAcquired;
-
     private Long amountPublishedNews;
+    private Long amountPublishedEvents;
 }

--- a/service-api/src/main/java/greencity/dto/user/UserProfileStatisticsDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileStatisticsDto.java
@@ -12,5 +12,5 @@ public class UserProfileStatisticsDto {
     private Long amountHabitsInProgress;
     private Long amountHabitsAcquired;
     private Long amountPublishedNews;
-    private Long amountPublishedEvents;
+    private Long amountOrganizedAndAttendedEvents;
 }

--- a/service-api/src/test/java/greencity/client/RestClientTest.java
+++ b/service-api/src/test/java/greencity/client/RestClientTest.java
@@ -235,4 +235,25 @@ class RestClientTest {
             ubsProfileCreationDto, Long.class);
         assertEquals(1L, id);
     }
+
+    @Test
+    void findAmountOfEventsOrganizedAndAttendedByUserTest() {
+        String accessToken = "accessToken";
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        Long userId = 1L;
+        when(httpServletRequest.getHeader(AUTHORIZATION)).thenReturn(accessToken);
+        when(restTemplate.exchange(greenCityServerAddress
+            + RestTemplateLinks.EVENTS_ORGANIZED_OR_ATTENDED_BY_USER_COUNT
+            + RestTemplateLinks.USER_ID + userId, HttpMethod.GET, entity, Long.class))
+                .thenReturn(ResponseEntity.ok(1L));
+
+        assertEquals(1, restClient.findAmountOfEventsOrganizedAndAttendedByUser(userId));
+
+        verify(httpServletRequest).getHeader(AUTHORIZATION);
+        verify(restTemplate).exchange(greenCityServerAddress
+            + RestTemplateLinks.EVENTS_ORGANIZED_OR_ATTENDED_BY_USER_COUNT
+            + RestTemplateLinks.USER_ID + userId, HttpMethod.GET, entity, Long.class);
+    }
 }

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -740,17 +740,20 @@ public class UserServiceImpl implements UserService {
      *
      * @param userId - {@link UserVO}'s id
      * @author Marian Datsko
+     * @author Olena Sotnik
      */
     @Override
     public UserProfileStatisticsDto getUserProfileStatistics(Long userId) {
         Long amountOfPublishedNewsByUserId = restClient.findAmountOfPublishedNews(userId);
         Long amountOfAcquiredHabitsByUserId = restClient.findAmountOfAcquiredHabits(userId);
         Long amountOfHabitsInProgressByUserId = restClient.findAmountOfHabitsInProgress(userId);
+        Long amountOfPublishedEventsByUserId = restClient.findAmountOfEventsPublishedByUser(userId);
 
         return UserProfileStatisticsDto.builder()
             .amountPublishedNews(amountOfPublishedNewsByUserId)
             .amountHabitsAcquired(amountOfAcquiredHabitsByUserId)
             .amountHabitsInProgress(amountOfHabitsInProgressByUserId)
+            .amountPublishedEvents(amountOfPublishedEventsByUserId)
             .build();
     }
 

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -747,13 +747,14 @@ public class UserServiceImpl implements UserService {
         Long amountOfPublishedNewsByUserId = restClient.findAmountOfPublishedNews(userId);
         Long amountOfAcquiredHabitsByUserId = restClient.findAmountOfAcquiredHabits(userId);
         Long amountOfHabitsInProgressByUserId = restClient.findAmountOfHabitsInProgress(userId);
-        Long amountOfPublishedEventsByUserId = restClient.findAmountOfEventsPublishedByUser(userId);
+        Long amountOfOrganizedAndAttendedEventsByUserId = restClient
+            .findAmountOfEventsOrganizedAndAttendedByUser(userId);
 
         return UserProfileStatisticsDto.builder()
             .amountPublishedNews(amountOfPublishedNewsByUserId)
             .amountHabitsAcquired(amountOfAcquiredHabitsByUserId)
             .amountHabitsInProgress(amountOfHabitsInProgressByUserId)
-            .amountPublishedEvents(amountOfPublishedEventsByUserId)
+            .amountOrganizedAndAttendedEvents(amountOfOrganizedAndAttendedEventsByUserId)
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -150,6 +150,7 @@ public class ModelUtils {
             .amountHabitsInProgress(TestConst.SIMPLE_LONG_NUMBER)
             .amountHabitsAcquired(TestConst.SIMPLE_LONG_NUMBER)
             .amountPublishedNews(TestConst.SIMPLE_LONG_NUMBER)
+            .amountPublishedEvents(TestConst.SIMPLE_LONG_NUMBER)
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -150,7 +150,7 @@ public class ModelUtils {
             .amountHabitsInProgress(TestConst.SIMPLE_LONG_NUMBER)
             .amountHabitsAcquired(TestConst.SIMPLE_LONG_NUMBER)
             .amountPublishedNews(TestConst.SIMPLE_LONG_NUMBER)
-            .amountPublishedEvents(TestConst.SIMPLE_LONG_NUMBER)
+            .amountOrganizedAndAttendedEvents(TestConst.SIMPLE_LONG_NUMBER)
             .build();
     }
 

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -564,26 +564,25 @@ class UserServiceImplTest {
     }
 
     @Test
-    void geTUserProfileStatistics() {
+    void getUserProfileStatistics() {
         when(restClient.findAmountOfPublishedNews(TestConst.SIMPLE_LONG_NUMBER))
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
         when(restClient.findAmountOfAcquiredHabits(TestConst.SIMPLE_LONG_NUMBER))
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
         when(restClient.findAmountOfHabitsInProgress(TestConst.SIMPLE_LONG_NUMBER))
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
-        when(restClient.findAmountOfEventsPublishedByUser(TestConst.SIMPLE_LONG_NUMBER))
+        when(restClient.findAmountOfEventsOrganizedAndAttendedByUser(TestConst.SIMPLE_LONG_NUMBER))
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
 
-        userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER);
         assertEquals(ModelUtils.USER_PROFILE_STATISTICS_DTO,
             userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER));
         assertNotEquals(ModelUtils.USER_PROFILE_STATISTICS_DTO,
             userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER_BAD_VALUE));
 
-        verify(restClient).findAmountOfPublishedNews(anyLong());
-        verify(restClient).findAmountOfAcquiredHabits(anyLong());
-        verify(restClient).findAmountOfHabitsInProgress(anyLong());
-        verify(restClient).findAmountOfEventsPublishedByUser(anyLong());
+        verify(restClient, times(2)).findAmountOfPublishedNews(anyLong());
+        verify(restClient, times(2)).findAmountOfAcquiredHabits(anyLong());
+        verify(restClient, times(2)).findAmountOfHabitsInProgress(anyLong());
+        verify(restClient, times(2)).findAmountOfEventsOrganizedAndAttendedByUser(anyLong());
     }
 
     @Test

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -571,11 +571,19 @@ class UserServiceImplTest {
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
         when(restClient.findAmountOfHabitsInProgress(TestConst.SIMPLE_LONG_NUMBER))
             .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
+        when(restClient.findAmountOfEventsPublishedByUser(TestConst.SIMPLE_LONG_NUMBER))
+            .thenReturn(TestConst.SIMPLE_LONG_NUMBER);
+
         userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER);
         assertEquals(ModelUtils.USER_PROFILE_STATISTICS_DTO,
             userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER));
         assertNotEquals(ModelUtils.USER_PROFILE_STATISTICS_DTO,
             userService.getUserProfileStatistics(TestConst.SIMPLE_LONG_NUMBER_BAD_VALUE));
+
+        verify(restClient).findAmountOfPublishedNews(anyLong());
+        verify(restClient).findAmountOfAcquiredHabits(anyLong());
+        verify(restClient).findAmountOfHabitsInProgress(anyLong());
+        verify(restClient).findAmountOfEventsPublishedByUser(anyLong());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUser PR
[[Friend's page] There is no counter of events (organized/visited) #6463](https://github.com/ita-social-projects/GreenCity/issues/6463)
## Summary Of Changes :fire:
Updated DTO that returns statistic info about user. Added new field amountPublishedEvents;
Updated tests. 
Created method findAmountOfEventsPublishedByUser() in RestClient.

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
