### PR TITLE
Rewrite put profile nested dto

### DIFF
--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -355,8 +355,10 @@ class UserControllerTest {
             + "\t\"showLocation\": true,\n"
             + "\t\"showEcoPlace\": true,\n"
             + "\t\"showShoppingList\": false,\n"
+            + "\t\"coordinates\":{ \n "
             + "\t\"latitude\": 20.000000,\n"
             + "\t\"longitude\": 20.000000\n"
+            + "\t}\n"
             + "}";
         String accessToken = "accessToken";
         HttpHeaders headers = new HttpHeaders();

--- a/dao/src/main/java/greencity/entity/UserLocation.java
+++ b/dao/src/main/java/greencity/entity/UserLocation.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -49,6 +51,7 @@ public class UserLocation {
     @Column(name = "longitude")
     private Double longitude;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "userLocation", fetch = FetchType.LAZY)
     private List<User> users;
 }

--- a/dao/src/main/java/greencity/repository/UserLocationRepo.java
+++ b/dao/src/main/java/greencity/repository/UserLocationRepo.java
@@ -19,6 +19,7 @@ public interface UserLocationRepo extends JpaRepository<UserLocation, Long> {
      *
      * @return {@link List} of {@link String} of cities
      **/
-    @Query(value = "SELECT u.userLocation FROM User u WHERE u.id =:userId")
+    // @Query(value = "SELECT u.userLocation FROM User u WHERE u.id =:userId")
+    @Query("SELECT ul FROM UserLocation ul JOIN ul.users u WHERE u.id = :userId")
     Optional<UserLocation> findAllUsersCities(Long userId);
 }

--- a/dao/src/main/java/greencity/repository/UserLocationRepo.java
+++ b/dao/src/main/java/greencity/repository/UserLocationRepo.java
@@ -19,7 +19,6 @@ public interface UserLocationRepo extends JpaRepository<UserLocation, Long> {
      *
      * @return {@link List} of {@link String} of cities
      **/
-    // @Query(value = "SELECT u.userLocation FROM User u WHERE u.id =:userId")
     @Query("SELECT ul FROM UserLocation ul JOIN ul.users u WHERE u.id = :userId")
     Optional<UserLocation> findAllUsersCities(Long userId);
 }

--- a/dao/src/main/java/greencity/repository/UserLocationRepo.java
+++ b/dao/src/main/java/greencity/repository/UserLocationRepo.java
@@ -19,6 +19,6 @@ public interface UserLocationRepo extends JpaRepository<UserLocation, Long> {
      *
      * @return {@link List} of {@link String} of cities
      **/
-    @Query("SELECT ul FROM UserLocation ul JOIN ul.users u WHERE u.id = :userId")
+    @Query(value = "SELECT u.userLocation FROM User u WHERE u.id =:userId")
     Optional<UserLocation> findAllUsersCities(Long userId);
 }

--- a/service-api/src/main/java/greencity/dto/CoordinatesDto.java
+++ b/service-api/src/main/java/greencity/dto/CoordinatesDto.java
@@ -3,13 +3,11 @@ package greencity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@EqualsAndHashCode
 @Builder
 public class CoordinatesDto {
     private Double latitude;

--- a/service-api/src/main/java/greencity/dto/CoordinatesDto.java
+++ b/service-api/src/main/java/greencity/dto/CoordinatesDto.java
@@ -2,15 +2,13 @@ package greencity.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@Setter
+@Data
 @EqualsAndHashCode
 @Builder
 public class CoordinatesDto {

--- a/service-api/src/main/java/greencity/dto/CoordinatesDto.java
+++ b/service-api/src/main/java/greencity/dto/CoordinatesDto.java
@@ -1,0 +1,19 @@
+package greencity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@Builder
+public class CoordinatesDto {
+    private Double latitude;
+    private Double longitude;
+}

--- a/service-api/src/main/java/greencity/dto/user/UserProfileDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileDtoRequest.java
@@ -1,6 +1,7 @@
 package greencity.dto.user;
 
 import greencity.annotations.ValidSocialNetworkLinks;
+import greencity.dto.CoordinatesDto;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Getter;
@@ -31,6 +32,5 @@ public class UserProfileDtoRequest {
     private Boolean showLocation;
     private Boolean showEcoPlace;
     private Boolean showShoppingList;
-    private Double latitude;
-    private Double longitude;
+    private CoordinatesDto coordinates;
 }

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -603,13 +603,17 @@ public class UserServiceImpl implements UserService {
         if (userProfileDtoRequest.getName() != null) {
             user.setName(userProfileDtoRequest.getName());
         }
-        GeocodingResult resultsUk = googleApiService.getLocationByCoordinates(userProfileDtoRequest.getLatitude(),
-            userProfileDtoRequest.getLongitude(), "uk");
-        GeocodingResult resultsEn = googleApiService.getLocationByCoordinates(userProfileDtoRequest.getLatitude(),
-            userProfileDtoRequest.getLongitude(), "en");
-
+        GeocodingResult resultsUk = googleApiService.getLocationByCoordinates(
+            userProfileDtoRequest.getCoordinates().getLatitude(),
+            userProfileDtoRequest.getCoordinates().getLongitude(),
+            "uk");
+        GeocodingResult resultsEn = googleApiService.getLocationByCoordinates(
+            userProfileDtoRequest.getCoordinates().getLatitude(),
+            userProfileDtoRequest.getCoordinates().getLongitude(),
+            "en");
         UserLocation userLocation = userLocationRepo.getUserLocationByLatitudeAndLongitude(
-            userProfileDtoRequest.getLatitude(), userProfileDtoRequest.getLongitude()).orElse(new UserLocation());
+            userProfileDtoRequest.getCoordinates().getLatitude(),
+            userProfileDtoRequest.getCoordinates().getLongitude()).orElse(new UserLocation());
 
         if (user.getUserLocation() != null && user.getUserLocation().getUsers().size() == 1) {
             if (userLocation.getId() != null) {
@@ -622,8 +626,8 @@ public class UserServiceImpl implements UserService {
         }
         initializeGeoCodingResults(initializeUkrainianGeoCodingResult(userLocation), resultsUk);
         initializeGeoCodingResults(initializeEnglishGeoCodingResult(userLocation), resultsEn);
-        userLocation.setLatitude(userProfileDtoRequest.getLatitude());
-        userLocation.setLongitude(userProfileDtoRequest.getLongitude());
+        userLocation.setLatitude(userProfileDtoRequest.getCoordinates().getLatitude());
+        userLocation.setLongitude(userProfileDtoRequest.getCoordinates().getLongitude());
         userLocation = userLocationRepo.save(userLocation);
         user.setUserLocation(userLocation);
         if (userProfileDtoRequest.getUserCredo() != null) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -6,6 +6,7 @@ import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.Geometry;
 import com.google.maps.model.LatLng;
 import greencity.constant.AppConstant;
+import greencity.dto.CoordinatesDto;
 import greencity.dto.UbsCustomerDto;
 import greencity.dto.achievement.AchievementVO;
 import greencity.dto.achievement.UserAchievementVO;
@@ -365,7 +366,6 @@ public class ModelUtils {
     public static UserProfileDtoRequest getUserProfileDtoRequest() {
         return UserProfileDtoRequest.builder()
             .name("Name")
-            // .city("City")
             .userCredo("userCredo")
             .socialNetworks(List.of(
                 "https://www.facebook.com",
@@ -373,6 +373,7 @@ public class ModelUtils {
                 "https://www.youtube.com",
                 "https://www.gmail.com",
                 "https://www.google.com"))
+            .coordinates(new CoordinatesDto(null, null))
             .showLocation(true)
             .showEcoPlace(true)
             .showShoppingList(true)

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -5,6 +5,7 @@ import greencity.TestConst;
 import greencity.client.RestClient;
 import greencity.constant.ErrorMessage;
 import greencity.constant.UpdateConstants;
+import greencity.dto.CoordinatesDto;
 import greencity.dto.PageableAdvancedDto;
 import greencity.dto.PageableDto;
 import greencity.dto.UbsCustomerDto;
@@ -627,14 +628,14 @@ class UserServiceImplTest {
         when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
         when(userRepo.save(user)).thenReturn(user);
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "uk"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "en"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
@@ -646,27 +647,27 @@ class UserServiceImplTest {
     @Test
     void saveUserProfileUpdatesValuesNull() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
+        CoordinatesDto coordinates = new CoordinatesDto();
         request.setName(null);
         request.setUserCredo(null);
         request.setSocialNetworks(null);
         request.setShowLocation(null);
         request.setShowEcoPlace(null);
         request.setShowShoppingList(null);
-        request.setLatitude(null);
-        request.setLongitude(null);
+        request.setCoordinates(coordinates);
 
         var user = ModelUtils.getUserWithSocialNetworks();
         when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
         when(userRepo.save(user)).thenReturn(user);
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "uk"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "en"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
@@ -680,33 +681,35 @@ class UserServiceImplTest {
     @Test
     void testUpdateUserProfileLocationWithTwoAssignedUsers() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
+        CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
+        request.setCoordinates(coordinates);
         request.setName("Dmutro");
-        request.setLatitude(20.0000);
-        request.setLongitude(20.0000);
         var user = ModelUtils.getUserWithSocialNetworks();
         var user2 = ModelUtils.getUser();
         UserLocation userLocation = new UserLocation();
         userLocation.setUsers(new ArrayList<>(Arrays.asList(user, user2)));
         when(userLocationRepo.getUserLocationByLatitudeAndLongitude(
-            request.getLatitude(), request.getLongitude())).thenReturn(Optional.of(userLocation));
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude()))
+                .thenReturn(Optional.of(userLocation));
         when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
         when(userRepo.save(user)).thenReturn(user);
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "uk"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "en"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
-        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(request.getLatitude(), request.getLongitude());
-        verify(googleApiService, times(2)).getLocationByCoordinates(eq(request.getLatitude()),
-            eq(request.getLongitude()), anyString());
+        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
+        verify(googleApiService, times(2)).getLocationByCoordinates(
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
         verify(userRepo).save(user);
     }
 
@@ -714,33 +717,35 @@ class UserServiceImplTest {
     void testUpdateUserProfileLocationWhenUserHasAUserLocation() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
-        request.setLatitude(20.0000);
-        request.setLongitude(20.0000);
+        CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
+        request.setCoordinates(coordinates);
         var user = ModelUtils.getUserWithUserLocation();
         UserLocation userLocation2 = ModelUtils.getUserLocation2();
         user.getUserLocation().setUsers(Collections.singletonList(user));
 
         when(userLocationRepo.getUserLocationByLatitudeAndLongitude(
-            request.getLatitude(), request.getLongitude())).thenReturn(Optional.of(userLocation2));
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude()))
+                .thenReturn(Optional.of(userLocation2));
         when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
         when(userRepo.save(user)).thenReturn(user);
         when(userLocationRepo.save(userLocation2)).thenReturn(userLocation2);
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "uk"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "en"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
-        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(request.getLatitude(), request.getLongitude());
-        verify(googleApiService, times(2)).getLocationByCoordinates(eq(request.getLatitude()),
-            eq(request.getLongitude()), anyString());
+        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
+        verify(googleApiService, times(2)).getLocationByCoordinates(
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
         verify(userLocationRepo).save(userLocation2);
         verify(userRepo).save(user);
         verify(userLocationRepo).delete(any());
@@ -750,32 +755,34 @@ class UserServiceImplTest {
     void testUpdateUserProfileLocationWhenUserModifyUserLocation() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
-        request.setLatitude(20.0000);
-        request.setLongitude(20.0000);
+        CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
+        request.setCoordinates(coordinates);
         var user = ModelUtils.getUserWithUserLocation();
         user.getUserLocation().setUsers(Collections.singletonList(user));
         when(userLocationRepo.getUserLocationByLatitudeAndLongitude(
-            request.getLatitude(), request.getLongitude())).thenReturn(Optional.of(new UserLocation()));
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude()))
+                .thenReturn(Optional.of(new UserLocation()));
         when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
         when(userRepo.save(user)).thenReturn(user);
 
         when(userLocationRepo.save(user.getUserLocation())).thenReturn(user.getUserLocation());
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "uk"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
 
         when(googleApiService.getLocationByCoordinates(
-            request.getLatitude(),
-            request.getLongitude(),
+            request.getCoordinates().getLatitude(),
+            request.getCoordinates().getLongitude(),
             "en"))
                 .thenReturn(ModelUtils.getGeocodingResult().get(0));
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
-        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(request.getLatitude(), request.getLongitude());
-        verify(googleApiService, times(2)).getLocationByCoordinates(eq(request.getLatitude()),
-            eq(request.getLongitude()), anyString());
+        verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
+            request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
+        verify(googleApiService, times(2)).getLocationByCoordinates(
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
         verify(userLocationRepo).save(any());
         verify(userRepo).save(user);
         verify(userLocationRepo, never()).delete(any());


### PR DESCRIPTION
# GreenCityUBS PR
Issue link [6664](https://github.com/ita-social-projects/GreenCity/issues/6664)

## Summary Of Changes :fire:
Now UserProfileDtoRequest accept nested dto 'coordinates' instead of simple fields 'latitude' and 'longitude'
Tests have been rewritten accordingly.
Issue with logging UserLocation.users field was solved.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers