### PR TITLE
modified logic to delete userLocation from user profile

### DIFF
--- a/service-api/src/main/java/greencity/dto/user/UserProfileDtoResponse.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileDtoResponse.java
@@ -26,5 +26,5 @@ public class UserProfileDtoResponse {
     private Boolean showShoppingList;
     private Float rating;
     private Role role;
-    private UserLocationDto userLocation;
+    private UserLocationDto userLocationDto;
 }

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -604,6 +604,38 @@ public class UserServiceImpl implements UserService {
         if (userProfileDtoRequest.getName() != null) {
             user.setName(userProfileDtoRequest.getName());
         }
+        if (userProfileDtoRequest.getUserCredo() != null) {
+            user.setUserCredo(userProfileDtoRequest.getUserCredo());
+        }
+        setLocationForUser(user, userProfileDtoRequest);
+        List<SocialNetwork> socialNetworks = user.getSocialNetworks();
+        if (userProfileDtoRequest.getSocialNetworks() != null) {
+            socialNetworks.forEach(socialNetwork -> restClient.deleteSocialNetwork(socialNetwork.getId()));
+            user.getSocialNetworks().clear();
+            user.getSocialNetworks().addAll(userProfileDtoRequest.getSocialNetworks()
+                .stream()
+                .map(url -> SocialNetwork.builder()
+                    .url(url)
+                    .user(user)
+                    .socialNetworkImage(modelMapper.map(restClient.getSocialNetworkImageByUrl(url),
+                        SocialNetworkImage.class))
+                    .build())
+                .collect(Collectors.toList()));
+        }
+        if (userProfileDtoRequest.getShowLocation() != null) {
+            user.setShowLocation(userProfileDtoRequest.getShowLocation());
+        }
+        if (userProfileDtoRequest.getShowEcoPlace() != null) {
+            user.setShowEcoPlace(userProfileDtoRequest.getShowEcoPlace());
+        }
+        if (userProfileDtoRequest.getShowShoppingList() != null) {
+            user.setShowShoppingList(userProfileDtoRequest.getShowShoppingList());
+        }
+        userRepo.save(user);
+        return UpdateConstants.getResultByLanguageCode(user.getLanguage().getCode());
+    }
+
+    private void setLocationForUser(User user, UserProfileDtoRequest userProfileDtoRequest) {
         if (user.getUserLocation() != null && (userProfileDtoRequest.getCoordinates().getLatitude() == null
             || userProfileDtoRequest.getCoordinates().getLongitude() == null)) {
             UserLocation old = user.getUserLocation();
@@ -651,34 +683,6 @@ public class UserServiceImpl implements UserService {
             userLocation = userLocationRepo.save(userLocation);
             user.setUserLocation(userLocation);
         }
-        if (userProfileDtoRequest.getUserCredo() != null) {
-            user.setUserCredo(userProfileDtoRequest.getUserCredo());
-        }
-        List<SocialNetwork> socialNetworks = user.getSocialNetworks();
-        if (userProfileDtoRequest.getSocialNetworks() != null) {
-            socialNetworks.forEach(socialNetwork -> restClient.deleteSocialNetwork(socialNetwork.getId()));
-            user.getSocialNetworks().clear();
-            user.getSocialNetworks().addAll(userProfileDtoRequest.getSocialNetworks()
-                .stream()
-                .map(url -> SocialNetwork.builder()
-                    .url(url)
-                    .user(user)
-                    .socialNetworkImage(modelMapper.map(restClient.getSocialNetworkImageByUrl(url),
-                        SocialNetworkImage.class))
-                    .build())
-                .collect(Collectors.toList()));
-        }
-        if (userProfileDtoRequest.getShowLocation() != null) {
-            user.setShowLocation(userProfileDtoRequest.getShowLocation());
-        }
-        if (userProfileDtoRequest.getShowEcoPlace() != null) {
-            user.setShowEcoPlace(userProfileDtoRequest.getShowEcoPlace());
-        }
-        if (userProfileDtoRequest.getShowShoppingList() != null) {
-            user.setShowShoppingList(userProfileDtoRequest.getShowShoppingList());
-        }
-        userRepo.save(user);
-        return UpdateConstants.getResultByLanguageCode(user.getLanguage().getCode());
     }
 
     private void initializeGeoCodingResults(Map<AddressComponentType, Consumer<String>> initializedMap,

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -21,6 +21,7 @@ import greencity.dto.user.UserAndAllFriendsWithOnlineStatusDto;
 import greencity.dto.user.UserAndFriendsWithOnlineStatusDto;
 import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.user.UserForListDto;
+import greencity.dto.user.UserLocationDto;
 import greencity.dto.user.UserManagementDto;
 import greencity.dto.user.UserManagementUpdateDto;
 import greencity.dto.user.UserManagementVO;
@@ -603,43 +604,53 @@ public class UserServiceImpl implements UserService {
         if (userProfileDtoRequest.getName() != null) {
             user.setName(userProfileDtoRequest.getName());
         }
-        GeocodingResult resultsUk = googleApiService.getLocationByCoordinates(
-            userProfileDtoRequest.getCoordinates().getLatitude(),
-            userProfileDtoRequest.getCoordinates().getLongitude(),
-            "uk");
-        GeocodingResult resultsEn = googleApiService.getLocationByCoordinates(
-            userProfileDtoRequest.getCoordinates().getLatitude(),
-            userProfileDtoRequest.getCoordinates().getLongitude(),
-            "en");
-        UserLocation userLocation = userLocationRepo.getUserLocationByLatitudeAndLongitude(
-            userProfileDtoRequest.getCoordinates().getLatitude(),
-            userProfileDtoRequest.getCoordinates().getLongitude()).orElse(new UserLocation());
+        if (userProfileDtoRequest.getCoordinates().getLatitude() == null
+            || userProfileDtoRequest.getCoordinates().getLongitude() == null) {
+            UserLocation old = user.getUserLocation();
+            old.getUsers().remove(user);
+            user.setUserLocation(null);
+        } else {
+            GeocodingResult resultsUk = googleApiService.getLocationByCoordinates(
+                userProfileDtoRequest.getCoordinates().getLatitude(),
+                userProfileDtoRequest.getCoordinates().getLongitude(),
+                "uk");
+            GeocodingResult resultsEn = googleApiService.getLocationByCoordinates(
+                userProfileDtoRequest.getCoordinates().getLatitude(),
+                userProfileDtoRequest.getCoordinates().getLongitude(),
+                "en");
+            UserLocation userLocation = userLocationRepo.getUserLocationByLatitudeAndLongitude(
+                userProfileDtoRequest.getCoordinates().getLatitude(),
+                userProfileDtoRequest.getCoordinates().getLongitude()).orElse(new UserLocation());
 
-        /*
-         * check if user already has a location and if he is the only one assigned to
-         * this location. If user do not have a location check if such location is in
-         * database, if true then assign it to user, if not - add new location to
-         * database and assign it to user. If user has a location and this location
-         * belongs only to him, modify this location. If user has a location but there
-         * are more users assigned to this location, then create a new location for this
-         * user. If user inserted same location get his location and do not change
-         * anything.
-         */
-        if (user.getUserLocation() != null && user.getUserLocation().getUsers().size() == 1) {
-            if (userLocation.getId() != null && user.getUserLocation() != userLocation) {
-                UserLocation deleteLocation = user.getUserLocation();
-                user.setUserLocation(userLocation);
-                userLocationRepo.delete(deleteLocation);
-            } else {
-                userLocation = user.getUserLocation();
+            /*
+             * check if user already has a location and if he is the only one assigned to
+             * this location. If user do not have a location check if such location is in
+             * database, if true then assign it to user, if not - add new location to
+             * database and assign it to user. If user has a location and this location
+             * belongs only to him, modify this location. If user has a location but there
+             * are more users assigned to this location, then create a new location for this
+             * user. If user inserted same location get his location and do not change
+             * anything.
+             */
+            if (user.getUserLocation() != null && user.getUserLocation().getUsers().size() == 1) {
+                if (userLocation.getId() != null && user.getUserLocation() != userLocation) {
+                    UserLocation deleteLocation = user.getUserLocation();
+                    user.setUserLocation(userLocation);
+                    userLocationRepo.delete(deleteLocation);
+                } else {
+                    userLocation = user.getUserLocation();
+                }
+            } else if (user.getUserLocation() != null && user.getUserLocation().getUsers().size() > 1) {
+                UserLocation old = user.getUserLocation();
+                old.getUsers().remove(user);
             }
+            initializeGeoCodingResults(initializeUkrainianGeoCodingResult(userLocation), resultsUk);
+            initializeGeoCodingResults(initializeEnglishGeoCodingResult(userLocation), resultsEn);
+            userLocation.setLatitude(userProfileDtoRequest.getCoordinates().getLatitude());
+            userLocation.setLongitude(userProfileDtoRequest.getCoordinates().getLongitude());
+            userLocation = userLocationRepo.save(userLocation);
+            user.setUserLocation(userLocation);
         }
-        initializeGeoCodingResults(initializeUkrainianGeoCodingResult(userLocation), resultsUk);
-        initializeGeoCodingResults(initializeEnglishGeoCodingResult(userLocation), resultsEn);
-        userLocation.setLatitude(userProfileDtoRequest.getCoordinates().getLatitude());
-        userLocation.setLongitude(userProfileDtoRequest.getCoordinates().getLongitude());
-        userLocation = userLocationRepo.save(userLocation);
-        user.setUserLocation(userLocation);
         if (userProfileDtoRequest.getUserCredo() != null) {
             user.setUserCredo(userProfileDtoRequest.getUserCredo());
         }
@@ -708,7 +719,7 @@ public class UserServiceImpl implements UserService {
 
         UserProfileDtoResponse userProfileDtoResponse = new UserProfileDtoResponse();
         if (user.getUserLocation() != null) {
-            userProfileDtoResponse = modelMapper.map(user.getUserLocation(), UserProfileDtoResponse.class);
+            userProfileDtoResponse.setUserLocationDto(modelMapper.map(user.getUserLocation(), UserLocationDto.class));
         }
         modelMapper.map(user, userProfileDtoResponse);
         return userProfileDtoResponse;

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -604,8 +604,8 @@ public class UserServiceImpl implements UserService {
         if (userProfileDtoRequest.getName() != null) {
             user.setName(userProfileDtoRequest.getName());
         }
-        if (userProfileDtoRequest.getCoordinates().getLatitude() == null
-            || userProfileDtoRequest.getCoordinates().getLongitude() == null) {
+        if (user.getUserLocation() != null && (userProfileDtoRequest.getCoordinates().getLatitude() == null
+            || userProfileDtoRequest.getCoordinates().getLongitude() == null)) {
             UserLocation old = user.getUserLocation();
             old.getUsers().remove(user);
             user.setUserLocation(null);

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -122,7 +122,7 @@ public class ModelUtils {
             .verifyEmail(new VerifyEmail())
             .dateOfRegistration(LocalDateTime.now())
             .userLocation(new UserLocation(1L, "Lviv", "Львів", "Lvivska", "Львівська", "Ukraine", "Україна", 20.000000,
-                20.000000, null))
+                20.000000, new ArrayList<User>()))
             .language(new Language(1L, "en", null))
             .build();
     }

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -762,6 +762,20 @@ class UserServiceImplTest {
     void testUpdateUserProfileDeleteLocation() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
+        CoordinatesDto coordinates = new CoordinatesDto(null, null);
+        request.setCoordinates(coordinates);
+        var user = ModelUtils.getUserWithUserLocation();
+        user.getUserLocation().getUsers().add(user);
+        when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
+        assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
+        verify(userRepo).save(user);
+        assertNull(user.getUserLocation());
+    }
+
+    @Test
+    void testUpdateUserProfileRemoveUserFromUserLocationList() {
+        UserProfileDtoRequest request = new UserProfileDtoRequest();
+        request.setName("Dmutro");
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
         request.setCoordinates(coordinates);
         var user = ModelUtils.getUserWithUserLocation();
@@ -796,18 +810,6 @@ class UserServiceImplTest {
             eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
         verify(userLocationRepo).save(userLocation2);
         verify(userRepo).save(user);
-    }
-
-    @Test
-    void testUpdateUserProfileRemoveUserFromUserLocationList() {
-        UserProfileDtoRequest request = new UserProfileDtoRequest();
-        request.setName("Dmutro");
-        CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
-        request.setCoordinates(coordinates);
-        var user = ModelUtils.getUserWithUserLocation();
-        user.getUserLocation().getUsers().add(user);
-        when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
-
     }
 
     @Test

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -759,6 +759,20 @@ class UserServiceImplTest {
     }
 
     @Test
+    void testUpdateUserProfileDeleteLocation() {
+        UserProfileDtoRequest request = new UserProfileDtoRequest();
+        request.setName("Dmutro");
+        CoordinatesDto coordinates = new CoordinatesDto(null, null);
+        request.setCoordinates(coordinates);
+        var user = ModelUtils.getUserWithUserLocation();
+        user.getUserLocation().getUsers().add(user);
+        when(userRepo.findByEmail("test@gmail.com")).thenReturn(Optional.of(user));
+        assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
+        verify(userRepo).save(user);
+        assertNull(user.getUserLocation());
+    }
+
+    @Test
     void testUpdateUserProfileLocationWhenUserModifyUserLocation() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");


### PR DESCRIPTION
# GreenCityUBS PR
Link on issue [6684](https://github.com/ita-social-projects/GreenCity/issues/6684)

## Summary Of Changes :fire:
Changed variable's name in UserProfileDtoResponse
Modified logic in saveUserProfile method to accept null values for coordinates. In this case old userLocatation is removed. Also
fixed bug when user changed location but old location still kept user in its list.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the dev branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] NEED_REVIEW and READY_FOR_REVIEW labels are added.
- [x] All files reviewed before sending to reviewers