### PR TITLE
Fix bug with default authorities for admin position

### DIFF
--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -200,7 +200,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
             .flatMap(position -> Stream.of(position.getName(), position.getNameEn()))
             .collect(Collectors.toList());
         List<Authority> list = authorityRepo.findAuthoritiesByPositions(positionNames);
-        employee.setAuthorities(list);
+        checkAdminPosition(positionNames, employee, list);
 
         List<Position> positions = positionRepo.findPositionsByNames(positionNames);
         employee.setPositions(positions);
@@ -215,6 +215,23 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         }
 
         return new SuccessSignUpDto(employee.getId(), employee.getName(), employee.getEmail(), true);
+    }
+
+    private void checkAdminPosition(List<String> positionNames, User employee, List<Authority> list) {
+        if (positionNames.size() <= 2 && (positionNames.contains("Admin") || positionNames.contains("Адмін"))) {
+            employee.setAuthorities(list.stream()
+                .filter(authority -> !isExcludedAuthority(authority.getName()))
+                .toList());
+        } else {
+            employee.setAuthorities(list);
+        }
+    }
+
+    private boolean isExcludedAuthority(String name) {
+        return name.equals("CREATE_NEW_LOCATION")
+            || name.equals("CREATE_NEW_COURIER")
+            || name.equals("CREATE_NEW_STATION")
+            || name.equals("CREATE_PRICING_CARD");
     }
 
     static List<UserAchievement> getUserAchievements(User user, AchievementService achievementService) {


### PR DESCRIPTION
# GreenCity PR

## Summary Of Changes :fire:
Added a check for when creating an employee with only an administrator role
![admin](https://github.com/ita-social-projects/GreenCityUser/assets/113462277/9440c093-cebc-4731-ad39-63cde861bad0)

## Issue Link :clipboard:
[#6403](https://github.com/ita-social-projects/GreenCity/issues/6403)

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
