### PR TITLE
Changes permissions to habit assign notifications endpoint

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -133,8 +133,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST,
                     "/ownSecurity/signUp",
                     "/ownSecurity/signIn",
-                    "/ownSecurity/updatePassword",
-                    "/email/habitAssign/notification")
+                    "/ownSecurity/updatePassword")
                 .permitAll()
                 .requestMatchers(HttpMethod.GET,
                     "/user/shopping-list-items/habits/{habitId}/shopping-list",
@@ -211,7 +210,8 @@ public class SecurityConfig {
                     "/email/sendHabitNotification",
                     "/email/addEcoNews",
                     "/email/changePlaceStatus",
-                    "/email/general/notification")
+                    "/email/general/notification",
+                    "/email/habitAssign/notification")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.PATCH,
                     "/user/status",


### PR DESCRIPTION
# GreenCityUser PR

Changes permissions to habit assign notifications endpoint

## Summary Of Changes :fire:
Only the administrator has permission to access the "/email/habitAssign/notification" endpoint.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
