### PR TITLE
3015 delete user profile and change password

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -181,7 +181,8 @@ public class SecurityConfig {
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.DELETE,
                     "/user/shopping-list-items/user-shopping-list-items",
-                    "/user/shopping-list-items")
+                    "/user/shopping-list-items",
+                    "/ownSecurity/user")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     USER_LINK,

--- a/core/src/main/java/greencity/security/controller/OwnSecurityController.java
+++ b/core/src/main/java/greencity/security/controller/OwnSecurityController.java
@@ -2,14 +2,26 @@ package greencity.security.controller;
 
 import greencity.annotations.ApiLocale;
 import greencity.annotations.ValidLanguage;
-import static greencity.constant.ErrorMessage.*;
+import static greencity.constant.ErrorMessage.NO_EMAIL_FOUND_FOR_VERIFICATION_WITH_THIS_TOKEN;
+import static greencity.constant.ErrorMessage.PASSWORD_DOES_NOT_MATCH;
+import static greencity.constant.ErrorMessage.REFRESH_TOKEN_NOT_VALID;
+import static greencity.constant.ErrorMessage.TOKEN_FOR_RESTORE_IS_INVALID;
+import static greencity.constant.ErrorMessage.USER_ALREADY_REGISTERED_WITH_THIS_EMAIL;
+import static greencity.constant.ErrorMessage.USER_NOT_FOUND_BY_EMAIL;
+import greencity.constant.ErrorMessage;
 import greencity.constant.HttpStatuses;
 import static greencity.constant.ValidationConstants.USER_CREATED;
 import greencity.dto.user.UserAdminRegistrationDto;
 import greencity.dto.user.UserManagementDto;
 import greencity.security.dto.SuccessSignInDto;
 import greencity.security.dto.SuccessSignUpDto;
-import greencity.security.dto.ownsecurity.*;
+import greencity.security.dto.ownsecurity.EmployeeSignUpDto;
+import greencity.security.dto.ownsecurity.OwnRestoreDto;
+import greencity.security.dto.ownsecurity.OwnSignInDto;
+import greencity.security.dto.ownsecurity.OwnSignUpDto;
+import greencity.security.dto.ownsecurity.PasswordStatusDto;
+import greencity.security.dto.ownsecurity.SetPasswordDto;
+import greencity.security.dto.ownsecurity.UpdatePasswordDto;
 import greencity.security.service.OwnSecurityService;
 import greencity.security.service.PasswordRecoveryService;
 import greencity.security.service.VerifyEmailService;
@@ -31,7 +43,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controller that provides our sign-up and sign-in logic.
@@ -256,5 +276,23 @@ public class OwnSecurityController {
         String email = authentication.getName();
         service.setPassword(dto, email);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * Method for deleting (deactivating) a user by email.
+     *
+     * @return {@link ResponseEntity}
+     */
+    @Operation(summary = "Delete (deactivate) a user by email.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "404", description = ErrorMessage.USER_NOT_FOUND_BY_EMAIL)
+    })
+    @DeleteMapping("/user")
+    public ResponseEntity<Object> deleteUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        service.deleteUserByEmail(email);
+        return ResponseEntity.ok().build();
     }
 }

--- a/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
+++ b/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
@@ -5,9 +5,12 @@ import greencity.security.dto.ownsecurity.EmployeeSignUpDto;
 import greencity.security.dto.ownsecurity.OwnRestoreDto;
 import greencity.security.dto.ownsecurity.OwnSignInDto;
 import greencity.security.dto.ownsecurity.OwnSignUpDto;
+import greencity.security.dto.ownsecurity.SetPasswordDto;
+import greencity.security.dto.ownsecurity.UpdatePasswordDto;
 import greencity.security.service.OwnSecurityService;
 import greencity.security.service.PasswordRecoveryService;
 import greencity.security.service.VerifyEmailService;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,9 +20,14 @@ import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -40,12 +48,19 @@ class OwnSecurityControllerTest {
     @Mock
     private PasswordRecoveryService passwordRecoveryService;
 
+    String email;
+
     @BeforeEach
     void setUp() {
+        email = "test@mail.com";
+
         this.mockMvc = MockMvcBuilders
             .standaloneSetup(ownSecurityController)
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
             .build();
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(email, "password");
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
@@ -153,5 +168,62 @@ class OwnSecurityControllerTest {
             .andExpect(status().isOk());
 
         verify(passwordRecoveryService).updatePasswordUsingToken(form);
+    }
+
+    @Test
+    @SneakyThrows
+    void setPassword() {
+        String content = """
+            {
+              "password": "String123=",
+              "confirmPassword": "String123="
+            }\
+            """;
+
+        mockMvc.perform(post(LINK + "/set-password")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+            .andExpect(status().isCreated());
+
+        SetPasswordDto dto = ModelUtils.getObjectMapper().readValue(content, SetPasswordDto.class);
+        verify(ownSecurityService).setPassword(dto, email);
+    }
+
+    @Test
+    @SneakyThrows
+    void hasPassword() {
+        mockMvc.perform(get(LINK + "/password-status"))
+            .andExpect(status().isOk());
+
+        verify(ownSecurityService).hasPassword(email);
+    }
+
+    @Test
+    void updatePasswordTest() throws Exception {
+        String content = """
+            {
+              "confirmPassword": "String123=",
+              "password": "String124="
+            }\
+            """;
+
+        mockMvc.perform(put(LINK + "/changePassword")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(content))
+            .andExpect(status().isOk());
+
+        UpdatePasswordDto dto =
+            ModelUtils.getObjectMapper().readValue(content, UpdatePasswordDto.class);
+
+        verify(ownSecurityService).updateCurrentPassword(dto, email);
+    }
+
+    @Test
+    @SneakyThrows
+    void deleteUser() {
+        mockMvc.perform(delete(LINK + "/user"))
+            .andExpect(status().isOk());
+
+        verify(ownSecurityService).deleteUserByEmail(email);
     }
 }

--- a/core/src/test/java/greencity/security/filters/AccessTokenAuthenticationFilterTest.java
+++ b/core/src/test/java/greencity/security/filters/AccessTokenAuthenticationFilterTest.java
@@ -83,7 +83,7 @@ class AccessTokenAuthenticationFilterTest {
         when(jwtTool.getTokenFromHttpServletRequest(request)).thenReturn(token);
         when(authenticationManager.authenticate(
             new UsernamePasswordAuthenticationToken(token, null)))
-                .thenThrow(ExpiredJwtException.class);
+            .thenThrow(ExpiredJwtException.class);
         authenticationFilter.doFilterInternal(request, response, chain);
         assertTrue(systemOutContent.toString().contains("Token has expired: "));
     }

--- a/core/src/test/java/greencity/security/filters/AccessTokenAuthenticationFilterTest.java
+++ b/core/src/test/java/greencity/security/filters/AccessTokenAuthenticationFilterTest.java
@@ -83,7 +83,7 @@ class AccessTokenAuthenticationFilterTest {
         when(jwtTool.getTokenFromHttpServletRequest(request)).thenReturn(token);
         when(authenticationManager.authenticate(
             new UsernamePasswordAuthenticationToken(token, null)))
-            .thenThrow(ExpiredJwtException.class);
+                .thenThrow(ExpiredJwtException.class);
         authenticationFilter.doFilterInternal(request, response, chain);
         assertTrue(systemOutContent.toString().contains("Token has expired: "));
     }

--- a/dao/src/main/java/greencity/enums/UserStatus.java
+++ b/dao/src/main/java/greencity/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package greencity.enums;
 
 public enum UserStatus {
-    BLOCKED, DEACTIVATED, ACTIVATED, CREATED
+    BLOCKED, DEACTIVATED, ACTIVATED, CREATED, DELETED
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -41,6 +41,7 @@ public class ErrorMessage {
     public static final String LINK_IS_NO_ACTIVE = "This link is no longer active";
     public static final String USER_BLOCKED = "User is blocked";
     public static final String USER_CREATED = "User is not activated";
+    public static final String USER_DELETED = "User deleted";
     public static final String USER_EMAIL_IS_NOT_VERIFIED = "The user's email address has not been verified.";
     public static final String NOT_FOUND_ADDRESS_BY_COORDINATES = "Not found address with such coordinates: ";
     public static final String USER_DID_NOT_SET_ANY_CITY = "User did not set any city";

--- a/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
+++ b/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
@@ -86,7 +86,8 @@ public interface OwnSecurityService {
     void setPassword(SetPasswordDto dto, String email);
 
     /**
-     * Method to delete (deactivate) a user by email, setting their status to DELETED.
+     * Method to delete (deactivate) a user by email, setting their status to
+     * DELETED.
      *
      * @param email {@link String} email of the user to be deleted.
      */

--- a/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
+++ b/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
@@ -53,14 +53,6 @@ public interface OwnSecurityService {
     AccessRefreshTokensDto updateAccessTokens(String refreshToken);
 
     /**
-     * Method for updating password.
-     *
-     * @param pass {@link String}
-     * @param id   {@link Long}
-     */
-    void updatePassword(String pass, Long id);
-
-    /**
      * Method for updating current password.
      *
      * @param updatePasswordDto {@link UpdatePasswordDto}
@@ -92,4 +84,11 @@ public interface OwnSecurityService {
      * @param email {@link String} email of user.
      */
     void setPassword(SetPasswordDto dto, String email);
+
+    /**
+     * Method to delete (deactivate) a user by email, setting their status to DELETED.
+     *
+     * @param email {@link String} email of the user to be deleted.
+     */
+    void deleteUserByEmail(String email);
 }

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -319,7 +319,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
     @Override
     public void deleteUserByEmail(String email) {
         User user = userRepo.findByEmail(email)
-                .orElseThrow(() -> new WrongEmailException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+            .orElseThrow(() -> new WrongEmailException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
 
         if (user.getUserStatus() != UserStatus.ACTIVATED) {
             throw new EmailNotVerified(ErrorMessage.USER_EMAIL_IS_NOT_VERIFIED);
@@ -459,8 +459,8 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
      * DEACTIVATED, BLOCKED, CREATED, or DELETED.
      *
      * @param status - the status of the User
-     * @throws BadUserStatusException if the user status is
-     * DEACTIVATED, BLOCKED, CREATED, or DELETED.
+     * @throws BadUserStatusException if the user status is DEACTIVATED, BLOCKED,
+     *                                CREATED, or DELETED.
      */
     private void handleUserStatus(UserStatus status) {
         switch (status) {

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -87,7 +86,6 @@ class OwnSecurityServiceImplTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
         ownSecurityService = new OwnSecurityServiceImpl(ownSecurityRepo, positionRepo, userService, passwordEncoder,
             jwtTool, restorePasswordEmailRepo, modelMapper, userRepo, emailService, authorityRepo);
 
@@ -329,7 +327,13 @@ class OwnSecurityServiceImplTest {
             .build();
         when(userService.findByEmail("test@gmail.com")).thenReturn(user);
         when(passwordEncoder.matches("password", "password")).thenReturn(true);
-        assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        Exception exception = assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        String expectedMessage = ErrorMessage.USER_DEACTIVATED;
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     @Test
@@ -343,7 +347,13 @@ class OwnSecurityServiceImplTest {
             .build();
         when(userService.findByEmail("test@gmail.com")).thenReturn(user);
         when(passwordEncoder.matches("password", "password")).thenReturn(true);
-        assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        Exception exception = assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        String expectedMessage = ErrorMessage.USER_BLOCKED;
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     @Test
@@ -355,9 +365,37 @@ class OwnSecurityServiceImplTest {
             .ownSecurity(OwnSecurityVO.builder().password("password").build())
             .role(Role.ROLE_USER)
             .build();
+
         when(userService.findByEmail("test@gmail.com")).thenReturn(user);
         when(passwordEncoder.matches("password", "password")).thenReturn(true);
-        assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        Exception exception = assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        String expectedMessage = ErrorMessage.USER_CREATED;
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    void signInDeletedUserTest() {
+        UserVO user = UserVO.builder()
+                .email("test@gmail.com")
+                .id(1L)
+                .userStatus(UserStatus.DELETED)
+                .ownSecurity(OwnSecurityVO.builder().password("password").build())
+                .role(Role.ROLE_USER)
+                .build();
+
+        when(userService.findByEmail("test@gmail.com")).thenReturn(user);
+        when(passwordEncoder.matches("password", "password")).thenReturn(true);
+
+        Exception exception = assertThrows(BadUserStatusException.class, () -> ownSecurityService.signIn(ownSignInDto));
+
+        String expectedMessage = ErrorMessage.USER_DELETED;
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     @Test
@@ -403,13 +441,6 @@ class OwnSecurityServiceImplTest {
         when(userService.findByEmail("test@gmail.com")).thenReturn(verifiedUser);
         assertThrows(UserDeactivatedException.class,
             () -> ownSecurityService.updateAccessTokens("12345"));
-    }
-
-    @Test
-    void updatePasswordTest() {
-        when(passwordEncoder.encode("password")).thenReturn("encodedPassword");
-        ownSecurityService.updatePassword("password", 1L);
-        verify(ownSecurityRepo).updatePassword("encodedPassword", 1L);
     }
 
     @Test
@@ -540,5 +571,47 @@ class OwnSecurityServiceImplTest {
         when(userRepo.findByEmail(email)).thenReturn(Optional.of(user));
 
         assertThrows(PasswordsDoNotMatchesException.class, () -> ownSecurityService.setPassword(dto, email));
+    }
+
+    @Test
+    void deleteUserByEmailTest() {
+        User deactivatedUser = User.builder()
+                .id(1L)
+                .email("test@somemail.com")
+                .userStatus(UserStatus.ACTIVATED)
+                .build();
+        Optional<User> optionalUser = Optional.of(deactivatedUser);
+
+        when(userRepo.findByEmail(deactivatedUser.getEmail())).thenReturn(optionalUser);
+
+        ownSecurityService.deleteUserByEmail(deactivatedUser.getEmail());
+        assertEquals(UserStatus.DELETED, deactivatedUser.getUserStatus());
+
+        verify(userRepo, times(1)).findByEmail(deactivatedUser.getEmail());
+        verify(userRepo, times(1)).save(deactivatedUser);
+    }
+
+    @Test
+    void deleteUserByEmail_UserNotExists() {
+        String nonExistUserEmail = "nonexistent@somemail.com";
+
+        when(userRepo.findByEmail(nonExistUserEmail)).thenReturn(Optional.empty());
+
+        assertThrows(WrongEmailException.class, () -> ownSecurityService.deleteUserByEmail(nonExistUserEmail));
+    }
+
+    @Test
+    void deleteUserByEmailNotVerifiedUserTest() {
+        User notVerifiedUser = User.builder()
+                .id(1L)
+                .email("test@somemail.com")
+                .userStatus(UserStatus.DEACTIVATED)
+                .build();
+        Optional<User> optionalUser = Optional.of(notVerifiedUser);
+
+        when(userRepo.findByEmail(notVerifiedUser.getEmail())).thenReturn(optionalUser);
+        assertThrows(EmailNotVerified.class, () -> ownSecurityService.deleteUserByEmail(notVerifiedUser.getEmail()));
+
+        verify(userRepo, times(1)).findByEmail(notVerifiedUser.getEmail());
     }
 }

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -380,12 +380,12 @@ class OwnSecurityServiceImplTest {
     @Test
     void signInDeletedUserTest() {
         UserVO user = UserVO.builder()
-                .email("test@gmail.com")
-                .id(1L)
-                .userStatus(UserStatus.DELETED)
-                .ownSecurity(OwnSecurityVO.builder().password("password").build())
-                .role(Role.ROLE_USER)
-                .build();
+            .email("test@gmail.com")
+            .id(1L)
+            .userStatus(UserStatus.DELETED)
+            .ownSecurity(OwnSecurityVO.builder().password("password").build())
+            .role(Role.ROLE_USER)
+            .build();
 
         when(userService.findByEmail("test@gmail.com")).thenReturn(user);
         when(passwordEncoder.matches("password", "password")).thenReturn(true);
@@ -576,10 +576,10 @@ class OwnSecurityServiceImplTest {
     @Test
     void deleteUserByEmailTest() {
         User deactivatedUser = User.builder()
-                .id(1L)
-                .email("test@somemail.com")
-                .userStatus(UserStatus.ACTIVATED)
-                .build();
+            .id(1L)
+            .email("test@somemail.com")
+            .userStatus(UserStatus.ACTIVATED)
+            .build();
         Optional<User> optionalUser = Optional.of(deactivatedUser);
 
         when(userRepo.findByEmail(deactivatedUser.getEmail())).thenReturn(optionalUser);
@@ -603,10 +603,10 @@ class OwnSecurityServiceImplTest {
     @Test
     void deleteUserByEmailNotVerifiedUserTest() {
         User notVerifiedUser = User.builder()
-                .id(1L)
-                .email("test@somemail.com")
-                .userStatus(UserStatus.DEACTIVATED)
-                .build();
+            .id(1L)
+            .email("test@somemail.com")
+            .userStatus(UserStatus.DEACTIVATED)
+            .build();
         Optional<User> optionalUser = Optional.of(notVerifiedUser);
 
         when(userRepo.findByEmail(notVerifiedUser.getEmail())).thenReturn(optionalUser);


### PR DESCRIPTION
[3015-Delete-user-profile_and_change-password](https://github.com/ita-social-projects/GreenCity/issues/3015)

Introduce functionality to deactivate users by setting their status to DELETED. Added corresponding methods in the service and controller layers, updated security configurations, and extended unit tests to cover this new feature.