### PR TITLE
Changed logic of email notifications

### DIFF
--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -149,19 +149,19 @@ public class EmailController {
     /**
      * Sends scheduled email notification to user.
      *
-     * @param message {@link ScheduledEmailMessage} - object with all
-     *                necessary data for sending notification via email.
+     * @param message {@link ScheduledEmailMessage} - object with all necessary data
+     *                for sending notification via email.
      * @author Dmytro Dmytruk
      */
     @Operation(summary = "Send scheduled email notification to user")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/scheduled/notification")
     public ResponseEntity<Void> sendScheduledNotification(
-            @RequestBody @Valid ScheduledEmailMessage message){
+        @RequestBody @Valid ScheduledEmailMessage message) {
         emailService.sendScheduledNotificationEmail(message);
         return ResponseEntity.ok().build();
     }

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -147,42 +147,22 @@ public class EmailController {
     }
 
     /**
-     * Sends email notification to user that received comment.
+     * Sends scheduled email notification to user.
      *
-     * @param message {@link UserReceivedCommentMessage} - object with all necessary
-     *                data for sending notification via email.
-     * @author Dmytro Dmytruk
-     */
-    @Operation(summary = "Send email notification user that received comment")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
-    })
-    @PostMapping("/userReceivedComment/notification")
-    public ResponseEntity<Void> sendUserReceivedCommentNotification(
-        @RequestBody @Valid UserReceivedCommentMessage message) {
-        emailService.sendUserReceivedCommentNotificationEmail(message);
-        return ResponseEntity.ok().build();
-    }
-
-    /**
-     * Sends email notification to user that received comment reply.
-     *
-     * @param message {@link UserReceivedCommentReplyMessage} - object with all
+     * @param message {@link ScheduledEmailMessage} - object with all
      *                necessary data for sending notification via email.
      * @author Dmytro Dmytruk
      */
-    @Operation(summary = "Send email notification user that received comment reply")
+    @Operation(summary = "Send scheduled email notification to user")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
-    @PostMapping("/userReceivedCommentReply/notification")
-    public ResponseEntity<Void> sendUserReceivedCommentReplyNotification(
-        @RequestBody @Valid UserReceivedCommentReplyMessage message) {
-        emailService.sendUserReceivedCommentReplyNotificationEmail(message);
+    @PostMapping("/scheduled/notification")
+    public ResponseEntity<Void> sendScheduledNotification(
+            @RequestBody @Valid ScheduledEmailMessage message){
+        emailService.sendScheduledNotificationEmail(message);
         return ResponseEntity.ok().build();
     }
 }

--- a/core/src/main/resources/templates/email/scheduled-notification-email-page.html
+++ b/core/src/main/resources/templates/email/scheduled-notification-email-page.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml"
+      th:with="lang=${language}" th:lang="${lang}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+        /**
+         * Google webfonts. Recommended to include the .woff version for cross-client compatibility.
+         */
+        @media screen {
+            @font-face {
+                font-family: 'Source Sans Pro';
+                font-style: normal;
+                font-weight: 400;
+                src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/ODelI1aHBYDBqgeIAH2zlBM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+            }
+            @font-face {
+                font-family: 'Source Sans Pro';
+                font-style: normal;
+                font-weight: 700;
+                src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'), url(https://fonts.gstatic.com/s/sourcesanspro/v10/toadOcfmlt9b38dHJxOBGFkQc6VGVFSmCnC_l7QZG60.woff) format('woff');
+            }
+        }
+
+        /**
+         * Avoid browser level font resizing.
+         * 1. Windows Mobile
+         * 2. iOS / OSX
+         */
+        body,
+        table,
+        td,
+        a {
+            -ms-text-size-adjust: 100%; /* 1 */
+            -webkit-text-size-adjust: 100%; /* 2 */
+        }
+
+        /**
+         * Remove extra space added to tables and cells in Outlook.
+         */
+        table,
+        td {
+            mso-table-rspace: 0pt;
+            mso-table-lspace: 0pt;
+        }
+
+        /**
+         * Better fluid images in Internet Explorer.
+         */
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        /**
+         * Remove blue links for iOS devices.
+         */
+        a[x-apple-data-detectors] {
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        /**
+         * Fix centering issues in Android 4.4.
+         */
+        div[style*="margin: 16px 0;"] {
+            margin: 0 !important;
+        }
+
+        body {
+            width: 100% !important;
+            height: 100% !important;
+            padding: 0 !important;
+            margin: 0 !important;
+        }
+
+        /**
+         * Collapse table borders to avoid space between cells.
+         */
+        table {
+            border-collapse: collapse !important;
+        }
+
+        .site-clr {
+            background-color: #13aa57;
+        }
+
+        .background-clr {
+            background-color: #e9ecef;
+        }
+
+        .background-msg-clr {
+            background-color: #ffffff;
+        }
+
+        img {
+            height: auto;
+            line-height: 100%;
+            text-decoration: none;
+            border: 0;
+            outline: none;
+        }
+    </style>
+
+</head>
+<body class="background-clr">
+<!-- start body -->
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <!-- start logo -->
+    <tr>
+        <td class="background-clr" align="center">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <tr>
+                    <td class="site-clr" align="center" valign="top" style="margin-top: 20px">
+                        <a style="display: inline-block; padding: 20px 50px; font-weight:700; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 32px; color: #ffffff; text-decoration: none; border-radius: 6px;">GreenCity</a>
+                    </td>
+                </tr>
+            </table>
+            <!--[if (gte mso 9)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    <!-- end logo -->
+
+    <!-- start hero -->
+    <tr>
+        <td class="background-clr" align="center">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <tr>
+                    <td class="background-msg-clr" align="left"
+                        style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;color: #000000; border-top: 3px solid #d4dadf;">
+                        <p th:text="#{hello} + ${name} + ','"
+                           style="margin: 0; font-size: 18px; font-weight: 700; letter-spacing: -1px; line-height: 12px;"></p>
+                    </td>
+                </tr>
+            </table>
+            <!--[if (gte mso 9)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+
+    <tr>
+        <td align="center" bgcolor="#e9ecef">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <!-- start copy -->
+                <tr>
+                    <td class="background-msg-clr" align="left"
+                        style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                        <div style="color: #000000">
+                            <span th:text="${title}" style="margin: 0; line-height: 5vh; display: inline-block; color: #000000; vertical-align: middle;">qewqewqew</span>
+                            <p th:utext="${body}">ererwerwerwewr</p>
+
+                        </div>
+                        <p style="margin: 0;">
+                            <a style="display: inline-block;
+                                        padding: 10px 20px;
+                                        margin-top: 20px;
+                                        font-size: 16px;
+                                        color: #fff;
+                                        background-color: #14a958;
+                                        text-decoration: none;
+                                        border-radius: 10px;"
+                               th:href="${clientLink}">Go to notification</a>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="background-msg-clr" align="left"
+                        style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; color: #000000; border-bottom: 3px solid #d4dadf">
+                        <p style="margin: 0;">Sincerely yours, GreenCity's team</p>
+                    </td>
+                </tr>
+                <!-- end copy -->
+
+            </table>
+            <!--[if (gte mso 9)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+
+
+    <tr>
+        <td class="background-clr" align="center" style="padding: 24px;">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+                <!-- start permission -->
+                <tr>
+                    <td class="background-clr" align="center"
+                        style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #666;">
+                        <p style="margin: 0;">
+                            You received this email because you subscribed for notifications via e-mail.
+                            If you didn't request this action you can safely delete this email.
+                        </p>
+                    </td>
+                </tr>
+                <!-- end permission -->
+
+            </table>
+            <!--[if (gte mso 9)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    <!-- end footer -->
+
+</table>
+<!-- end body -->
+</body>
+</html>

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -221,13 +221,13 @@ class EmailControllerTest {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         ScheduledEmailMessage message = ScheduledEmailMessage.builder()
-                .body("test body")
-                .username("test user")
-                .email("test@gmail.com")
-                .subject("test subject")
-                .baseLink("test link")
-                .language("en")
-                .build();
+            .body("test body")
+            .username("test user")
+            .email("test@gmail.com")
+            .subject("test subject")
+            .baseLink("test link")
+            .language("en")
+            .build();
         String content = objectMapper.writeValueAsString(message);
         mockMvc.perform(MockMvcRequestBuilders.post(LINK + "/scheduled/notification")
             .contentType(MediaType.APPLICATION_JSON)

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -5,7 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
 import greencity.dto.violation.UserViolationMailDto;
-import greencity.message.*;
+import greencity.message.GeneralEmailMessage;
+import greencity.message.HabitAssignNotificationMessage;
+import greencity.message.ScheduledEmailMessage;
+import greencity.message.SendChangePlaceStatusEmailMessage;
+import greencity.message.SendHabitNotification;
+import greencity.message.SendReportEmailMessage;
+import greencity.message.UserTaggedInCommentMessage;
 import greencity.service.EmailService;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -211,51 +217,21 @@ class EmailControllerTest {
 
     @Test
     @SneakyThrows
-    void sendUserReceivedCommentNotification() {
+    void sendUserReceivedScheduledNotification() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-        UserReceivedCommentMessage message = UserReceivedCommentMessage.builder()
-            .receiverEmail("receiver@example.com")
-            .receiverName("receiver")
-            .elementName("event")
-            .commentText("test")
-            .authorName("test")
-            .commentedElementId(1L)
-            .language("en")
-            .baseLink("testLink")
-            .creationDate(LocalDateTime.now())
-            .build();
+        ScheduledEmailMessage message = ScheduledEmailMessage.builder()
+                .body("test body")
+                .username("test user")
+                .email("test@gmail.com")
+                .subject("test subject")
+                .baseLink("test link")
+                .language("en")
+                .build();
         String content = objectMapper.writeValueAsString(message);
-        mockMvc.perform(MockMvcRequestBuilders.post(LINK + "/userReceivedComment/notification")
+        mockMvc.perform(MockMvcRequestBuilders.post(LINK + "/scheduled/notification")
             .contentType(MediaType.APPLICATION_JSON)
             .content(content))
             .andExpect(status().isOk());
     }
-
-    @Test
-    @SneakyThrows
-    void sendUserReceivedCommentReplyNotification() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        UserReceivedCommentReplyMessage message = UserReceivedCommentReplyMessage.builder()
-            .receiverEmail("receiver@example.com")
-            .receiverName("receiver")
-            .elementName("event")
-            .commentText("test")
-            .authorName("test")
-            .baseLink("testLink")
-            .commentedElementId(1L)
-            .language("en")
-            .parentCommentAuthorName("parent")
-            .parentCommentText("parentText")
-            .parentCommentCreationDate(LocalDateTime.now())
-            .creationDate(LocalDateTime.now())
-            .build();
-        String content = objectMapper.writeValueAsString(message);
-        mockMvc.perform(MockMvcRequestBuilders.post(LINK + "/userReceivedCommentReply/notification")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(content))
-            .andExpect(status().isOk());
-    }
-
 }

--- a/service-api/src/main/java/greencity/constant/EmailConstants.java
+++ b/service-api/src/main/java/greencity/constant/EmailConstants.java
@@ -48,6 +48,8 @@ public class EmailConstants {
     public static final String SENDER_NAME = "senderName";
     public static final String HABIT_NAME = "habitName";
     public static final String ELEMENT_NAME = "elementName";
+    public static final String TITLE = "title";
+    public static final String BODY = "body";
     // templates
     public static final String VERIFY_EMAIL_PAGE = "verify-email-page";
     public static final String RESTORE_EMAIL_PAGE = "restore-email-page";
@@ -64,4 +66,5 @@ public class EmailConstants {
     public static final String USER_TAGGED_IN_COMMENT_PAGE = "user-tagged-in-comment-email-page";
     public static final String USER_RECEIVED_COMMENT_PAGE = "user-received-comment-email-page";
     public static final String USER_RECEIVED_COMMENT_REPLY_PAGE = "user-received-comment-reply-email-page";
+    public static final String SCHEDULED_NOTIFICATION_PAGE = "scheduled-notification-email-page";
 }

--- a/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
+++ b/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
@@ -25,4 +25,3 @@ public class ScheduledEmailMessage implements Serializable {
     @NotEmpty(message = "Language cannot be empty")
     private String language;
 }
-

--- a/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
+++ b/service-api/src/main/java/greencity/message/ScheduledEmailMessage.java
@@ -1,0 +1,28 @@
+package greencity.message;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ScheduledEmailMessage implements Serializable {
+    @NotEmpty(message = "Username cannot be empty")
+    private String username;
+    @NotEmpty(message = "Email cannot be empty")
+    private String email;
+    @NotEmpty(message = "Link cannot be empty")
+    private String baseLink;
+    @NotEmpty(message = "Subject cannot be empty")
+    private String subject;
+    @NotEmpty(message = "Body cannot be empty")
+    private String body;
+    @NotEmpty(message = "Language cannot be empty")
+    private String language;
+}
+

--- a/service-api/src/main/java/greencity/service/EmailService.java
+++ b/service-api/src/main/java/greencity/service/EmailService.java
@@ -9,8 +9,7 @@ import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
-import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import java.util.List;
 import java.util.Map;
@@ -173,20 +172,11 @@ public interface EmailService {
     void sendTaggedUserInCommentNotificationEmail(UserTaggedInCommentMessage message);
 
     /**
-     * Sends an email notification user that received a comment
-     * {@link UserReceivedCommentMessage}.
+     * Sends an email notification user that received scheduled message
+     * {@link ScheduledEmailMessage}.
      *
-     * @param message {@link UserReceivedCommentMessage}
+     * @param message {@link ScheduledEmailMessage}
      * @author Dmytro Dmytruk
      */
-    void sendUserReceivedCommentNotificationEmail(UserReceivedCommentMessage message);
-
-    /**
-     * Sends an email notification user that received reply to the comment
-     * {@link UserReceivedCommentMessage}.
-     *
-     * @param message {@link UserReceivedCommentMessage}
-     * @author Dmytro Dmytruk
-     */
-    void sendUserReceivedCommentReplyNotificationEmail(UserReceivedCommentReplyMessage message);
+    void sendScheduledNotificationEmail(ScheduledEmailMessage message);
 }

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -1,6 +1,5 @@
 package greencity.service;
 
-import com.sun.mail.imap.protocol.BODY;
 import greencity.constant.EmailConstants;
 import greencity.constant.LogMessage;
 import greencity.dto.category.CategoryDto;
@@ -14,8 +13,6 @@ import greencity.exception.exceptions.LanguageNotSupportedException;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
 import greencity.message.ScheduledEmailMessage;
-import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import greencity.validator.EmailAddressValidator;
 import greencity.validator.LanguageValidationUtils;
@@ -342,9 +339,7 @@ public class EmailServiceImpl implements EmailService {
             null, getLocale(language)) + " " + message.getElementName(), template);
     }
 
-
-
-    public void sendScheduledNotificationEmail(ScheduledEmailMessage message){
+    public void sendScheduledNotificationEmail(ScheduledEmailMessage message) {
         Map<String, Object> model = new HashMap<>();
         String language = message.getLanguage();
         validateLanguage(language);

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import com.sun.mail.imap.protocol.BODY;
 import greencity.constant.EmailConstants;
 import greencity.constant.LogMessage;
 import greencity.dto.category.CategoryDto;
@@ -12,6 +13,7 @@ import greencity.dto.violation.UserViolationMailDto;
 import greencity.exception.exceptions.LanguageNotSupportedException;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.UserReceivedCommentMessage;
 import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
@@ -340,43 +342,20 @@ public class EmailServiceImpl implements EmailService {
             null, getLocale(language)) + " " + message.getElementName(), template);
     }
 
-    public void sendUserReceivedCommentNotificationEmail(UserReceivedCommentMessage message) {
-        Map<String, Object> model = new HashMap<>();
-        String language = message.getLanguage();
-        validateLanguage(language);
-        model.put(EmailConstants.CLIENT_LINK, message.getBaseLink());
-        model.put(EmailConstants.USER_NAME, message.getReceiverName());
-        model.put(EmailConstants.AUTHOR_NAME, message.getAuthorName());
-        model.put(EmailConstants.LANGUAGE, language);
-        model.put(EmailConstants.IS_UBS, false);
-        model.put(EmailConstants.ELEMENT_NAME, message.getElementName());
-        model.put(EmailConstants.COMMENT_TIME, message.getCreationDate());
-        model.put(EmailConstants.COMMENT_BODY, message.getCommentText());
-        String template = createEmailTemplate(model, EmailConstants.USER_RECEIVED_COMMENT_PAGE);
-        sendEmail(message.getReceiverEmail(), messageSource.getMessage(EmailConstants.USER_RECEIVED_COMMENT_REQUEST,
-            null, getLocale(language)) + " " + message.getElementName(), template);
-    }
 
-    public void sendUserReceivedCommentReplyNotificationEmail(UserReceivedCommentReplyMessage message) {
+
+    public void sendScheduledNotificationEmail(ScheduledEmailMessage message){
         Map<String, Object> model = new HashMap<>();
         String language = message.getLanguage();
         validateLanguage(language);
         model.put(EmailConstants.CLIENT_LINK, message.getBaseLink());
-        model.put(EmailConstants.USER_NAME, message.getReceiverName());
-        model.put(EmailConstants.ELEMENT_NAME, message.getElementName());
-        model.put(EmailConstants.AUTHOR_NAME, message.getAuthorName());
+        model.put(EmailConstants.USER_NAME, message.getUsername());
         model.put(EmailConstants.LANGUAGE, language);
         model.put(EmailConstants.IS_UBS, false);
-        model.put(EmailConstants.COMMENT_TIME, message.getCreationDate());
-        model.put(EmailConstants.COMMENT_BODY, message.getCommentText());
-        model.put(EmailConstants.PARENT_COMMENT_AUTHOR_NAME, message.getParentCommentAuthorName());
-        model.put(EmailConstants.PARENT_COMMENT_BODY, message.getParentCommentText());
-        model.put(EmailConstants.PARENT_COMMENT_TIME, message.getParentCommentCreationDate());
-        String template = createEmailTemplate(model, EmailConstants.USER_RECEIVED_COMMENT_REPLY_PAGE);
-        sendEmail(message.getReceiverEmail(),
-            message.getAuthorName() + " " + messageSource.getMessage(EmailConstants.USER_RECEIVED_COMMENT_REPLY_REQUEST,
-                null, getLocale(language)) + " " + message.getElementName(),
-            template);
+        model.put(EmailConstants.TITLE, message.getSubject());
+        model.put(EmailConstants.BODY, message.getBody());
+        String template = createEmailTemplate(model, EmailConstants.SCHEDULED_NOTIFICATION_PAGE);
+        sendEmail(message.getEmail(), message.getSubject(), template);
     }
 
     private Map<String, Object> buildModelMapForPasswordRestore(Long userId, String name, String token, String language,

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -248,13 +248,13 @@ class EmailServiceImplTest {
     @Test
     void sendScheduledNotificationEmailTest() {
         ScheduledEmailMessage message = ScheduledEmailMessage.builder()
-                .body("test body")
-                .username("test user")
-                .email("test@gmail.com")
-                .subject("test subject")
-                .baseLink("test link")
-                .language("en")
-                .build();
+            .body("test body")
+            .username("test user")
+            .email("test@gmail.com")
+            .subject("test subject")
+            .baseLink("test link")
+            .language("en")
+            .build();
         service.sendScheduledNotificationEmail(message);
         verify(javaMailSender).createMimeMessage();
     }

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -14,8 +14,6 @@ import greencity.exception.exceptions.WrongEmailException;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
 import greencity.message.ScheduledEmailMessage;
-import greencity.message.UserReceivedCommentMessage;
-import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -13,6 +13,7 @@ import greencity.exception.exceptions.LanguageNotSupportedException;
 import greencity.exception.exceptions.WrongEmailException;
 import greencity.message.GeneralEmailMessage;
 import greencity.message.HabitAssignNotificationMessage;
+import greencity.message.ScheduledEmailMessage;
 import greencity.message.UserReceivedCommentMessage;
 import greencity.message.UserReceivedCommentReplyMessage;
 import greencity.message.UserTaggedInCommentMessage;
@@ -244,47 +245,18 @@ class EmailServiceImplTest {
         verify(messageSource).getMessage(EmailConstants.USER_TAGGED_IN_COMMENT_REQUEST, null, getLocale(language));
     }
 
-    @ParameterizedTest
-    @CsvSource(value = {"ua", "en"})
-    void sendUserReceivedCommentNotificationTest(String language) {
-        UserReceivedCommentMessage message = UserReceivedCommentMessage.builder()
-            .receiverEmail("receiver@example.com")
-            .receiverName("receiver")
-            .elementName("event")
-            .commentText("test")
-            .authorName("author")
-            .commentedElementId(1L)
-            .language(language)
-            .creationDate(LocalDateTime.now())
-            .build();
-        when(messageSource.getMessage(EmailConstants.USER_RECEIVED_COMMENT_REQUEST, null, getLocale(language)))
-            .thenReturn("user received comment request");
-        service.sendUserReceivedCommentNotificationEmail(message);
+    @Test
+    void sendScheduledNotificationEmailTest() {
+        ScheduledEmailMessage message = ScheduledEmailMessage.builder()
+                .body("test body")
+                .username("test user")
+                .email("test@gmail.com")
+                .subject("test subject")
+                .baseLink("test link")
+                .language("en")
+                .build();
+        service.sendScheduledNotificationEmail(message);
         verify(javaMailSender).createMimeMessage();
-        verify(messageSource).getMessage(EmailConstants.USER_RECEIVED_COMMENT_REQUEST, null, getLocale(language));
-    }
-
-    @ParameterizedTest
-    @CsvSource(value = {"ua", "en"})
-    void sendUserReceivedCommentReplyNotificationTest(String language) {
-        UserReceivedCommentReplyMessage message = UserReceivedCommentReplyMessage.builder()
-            .receiverEmail("receiver@example.com")
-            .receiverName("receiver")
-            .elementName("event")
-            .commentText("test")
-            .authorName("author")
-            .commentedElementId(1L)
-            .language(language)
-            .creationDate(LocalDateTime.now())
-            .parentCommentCreationDate(LocalDateTime.now())
-            .parentCommentText("test")
-            .parentCommentAuthorName("parentAuthor")
-            .build();
-        when(messageSource.getMessage(EmailConstants.USER_RECEIVED_COMMENT_REPLY_REQUEST, null, getLocale(language)))
-            .thenReturn("user received comment request");
-        service.sendUserReceivedCommentReplyNotificationEmail(message);
-        verify(javaMailSender).createMimeMessage();
-        verify(messageSource).getMessage(EmailConstants.USER_RECEIVED_COMMENT_REPLY_REQUEST, null, getLocale(language));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
GreenCity PR
https://github.com/ita-social-projects/GreenCity/issues/7377

Summary Of Changes 🔥
Changed email notification logic, unread notifications with types

ECONEWS_COMMENT_LIKE
ECONEWS_LIKE
EVENT_COMMENT_LIKE
ECONEWS_COMMENT
EVENT_COMMENT
ECONEWS_COMMENT_REPLY
EVENT_COMMENT_REPLY
FRIEND_REQUEST_RECEIVED
FRIEND_REQUEST_ACCEPTED

are sent using new endpoint /scheduled/notification
Issue Link 📋
https://github.com/ita-social-projects/GreenCity/issues/7377

How to test 📋
PR Checklist Forms
(to be filled out by PR submitter)
[ ] Code is up-to-date with the dev branch.
[x] You've successfully built and run the tests locally.
[x] There are new or updated unit tests validating the change.
[x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
[x] This template filled (above this section).
[x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
[x] NEED_REVIEW and READY_FOR_REVIEW labels are added.
[x] All files reviewed before sending to reviewers