### PR TITLE
Sing up employee email sending fix

### DIFF
--- a/service-api/src/main/java/greencity/service/EmailService.java
+++ b/service-api/src/main/java/greencity/service/EmailService.java
@@ -169,12 +169,10 @@ public interface EmailService {
      *                         constants
      * @param employeeEmail    {@link String} user email which will be used for
      *                         sending recovery letter
-     * @param language         {@link String} language code used for email
-     *                         notification
      * @param token            {@link String} token for password save(restoration)
      *
      * @author Olena Sotnik
      */
     void sendCreateNewPasswordForEmployee(Long employeeId, String employeeFistName, String employeeEmail, String token,
-        String language, boolean isUbs);
+        boolean isUbs);
 }

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -203,9 +203,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
 
         try {
             User savedUser = userRepo.save(employee);
-            handlePostSaveActions(language, dto, employee, savedUser);
-            emailService.sendCreateNewPasswordForEmployee(employee.getId(), employee.getFirstName(),
-                employee.getEmail(), employee.getRestorePasswordEmail().getToken(), language, dto.isUbs());
+            handlePostSaveActions(dto, employee, savedUser);
         } catch (DataIntegrityViolationException e) {
             throw new UserAlreadyRegisteredException(ErrorMessage.USER_ALREADY_REGISTERED_WITH_THIS_EMAIL);
         }
@@ -240,16 +238,11 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         employee.setPositions(positions);
     }
 
-    private void handlePostSaveActions(String language, OwnSignUpDto dto, User employee, User savedUser) {
+    private void handlePostSaveActions(OwnSignUpDto dto, User employee, User savedUser) {
         employee.setId(savedUser.getId());
         if (!validateOnlyDriverPosition(employee) && employee.getRestorePasswordEmail() != null) {
-            emailService.sendRestoreEmail(
-                savedUser.getId(),
-                savedUser.getFirstName(),
-                employee.getEmail(),
-                savedUser.getRestorePasswordEmail().getToken(),
-                language,
-                dto.isUbs());
+            emailService.sendCreateNewPasswordForEmployee(employee.getId(), employee.getFirstName(),
+                employee.getEmail(), employee.getRestorePasswordEmail().getToken(), dto.isUbs());
         }
     }
 

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -363,12 +363,13 @@ public class EmailServiceImpl implements EmailService {
      */
     @Override
     public void sendCreateNewPasswordForEmployee(Long employeeId, String employeeFistName, String employeeEmail,
-        String token, String language, boolean isUbs) {
+        String token, boolean isUbs) {
+        String ukrainianLanguage = "ua";
         Map<String, Object> model =
-            buildModelMapForPasswordRestore(employeeId, employeeFistName, token, language, isUbs);
+            buildModelMapForPasswordRestore(employeeId, employeeFistName, token, ukrainianLanguage, isUbs);
         String template = createEmailTemplate(model, EmailConstants.CRETE_PASSWORD_PAGE);
         String emailSubject = isUbs ? EmailConstants.CONFIRM_CREATING_PASS_UBS : EmailConstants.CONFIRM_CREATING_PASS;
-        sendEmail(employeeEmail, messageSource.getMessage(emailSubject, null, getLocale(language)), template);
+        sendEmail(employeeEmail, messageSource.getMessage(emailSubject, null, getLocale(ukrainianLanguage)), template);
     }
 
     private Map<String, Object> buildModelMapForPasswordRestore(Long userId, String name, String token, String language,

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -305,15 +305,15 @@ class EmailServiceImplTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"1, Test, test@gmail.com, token, ua, false",
-        "1, Test, test@gmail.com, token, en, true"})
-    void sendCreateNewPasswordForEmployee(Long id, String name, String email, String token, String language,
+    @CsvSource(value = {"1, Test, test@gmail.com, token, false",
+        "1, Test, test@gmail.com, token, true"})
+    void sendCreateNewPasswordForEmployee(Long id, String name, String email, String token,
         Boolean isUbs) {
-        when(messageSource.getMessage(EmailConstants.CONFIRM_CREATING_PASS, null, getLocale(language)))
+        when(messageSource.getMessage(EmailConstants.CONFIRM_CREATING_PASS, null, getLocale("ua")))
             .thenReturn("Create password for Green City");
-        when(messageSource.getMessage(EmailConstants.CONFIRM_CREATING_PASS_UBS, null, getLocale(language)))
+        when(messageSource.getMessage(EmailConstants.CONFIRM_CREATING_PASS_UBS, null, getLocale("ua")))
             .thenReturn("Create password for Pick Up City");
-        service.sendCreateNewPasswordForEmployee(id, name, email, token, language, isUbs);
+        service.sendCreateNewPasswordForEmployee(id, name, email, token, isUbs);
         verify(javaMailSender).createMimeMessage();
     }
 


### PR DESCRIPTION
# GreenCityUser PROD PR

## Summary Of Changes:

The email for creating an employee's password now always uses the Ukrainian language.
The "Restore password" email is not sent when creating a new employee.

# PR Checklist Forms
_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `prod` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers