### PR TITLE
Change th:text to th:utext in scheduled-notification-email-page.html

### DIFF
--- a/core/src/main/resources/templates/email/scheduled-notification-email-page.html
+++ b/core/src/main/resources/templates/email/scheduled-notification-email-page.html
@@ -138,7 +138,7 @@
         </p>
 
         <p class="main-text">
-            <span th:text="${body}"></span>
+            <span th:utext="${body}"></span>
         </p>
 
         <div th:if="${isUbs == false}" class="vertical-center"><a th:text="#{notifications.button}" th:href="${notificationsLink}" class="notification-button" target="_blank"></a></div>


### PR DESCRIPTION
Replaced th:text with th:utext to enable raw HTML rendering in email templates. This update ensures that messages with HTML tags, such as those for bold text, are displayed correctly. For example, messages containing HTML tags will now be rendered as intended.
All other messages are displayed as they were previously.
# Result
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/071a3ac2-3ec0-464c-a305-b81f56738cff">
