### PR TITLE
Bugfix #7946 and #7945 - Fixed incorrect updating for location on edit profile page.

### DIFF
--- a/service/src/main/java/greencity/service/GoogleApiService.java
+++ b/service/src/main/java/greencity/service/GoogleApiService.java
@@ -4,6 +4,7 @@ import com.google.maps.GeoApiContext;
 import com.google.maps.GeocodingApi;
 import com.google.maps.errors.ApiException;
 import com.google.maps.errors.InvalidRequestException;
+import com.google.maps.model.AddressType;
 import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import greencity.constant.ErrorMessage;
@@ -11,6 +12,7 @@ import greencity.exception.exceptions.GoogleApiException;
 import greencity.exception.exceptions.NotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,15 +24,20 @@ public class GoogleApiService {
     /**
      * Method gets user location by coordinates.
      *
-     * @param latitude  user's latitude
-     * @param longitude user's longitude
-     * @return {@link greencity.entity.UserLocation}
+     * @param latitude    user's latitude
+     * @param longitude   user's longitude
+     * @param addressTypes preferred result_types that should be included in the
+     *                    result.
+     * @return {@link GeocodingResult}
      */
-    public GeocodingResult getLocationByCoordinates(Double latitude, Double longitude, String lang) {
+    public GeocodingResult getLocationByCoordinates(Double latitude, Double longitude, String lang,
+        AddressType[] addressTypes) {
         try {
             return Arrays.stream(GeocodingApi.newRequest(context).latlng(new LatLng(latitude, longitude))
-                .language(lang).await())
-                .findFirst()
+                .language(lang)
+                .resultType(addressTypes)
+                .await())
+                .max(Comparator.comparingInt(a -> a.addressComponents.length))
                 .orElseThrow(() -> new GoogleApiException("Geocoding result was not found"));
         } catch (InvalidRequestException e) {
             String formattedCoords = "%.8f,%.8f".formatted(latitude, longitude);

--- a/service/src/main/java/greencity/service/GoogleApiService.java
+++ b/service/src/main/java/greencity/service/GoogleApiService.java
@@ -24,10 +24,10 @@ public class GoogleApiService {
     /**
      * Method gets user location by coordinates.
      *
-     * @param latitude    user's latitude
-     * @param longitude   user's longitude
+     * @param latitude     user's latitude
+     * @param longitude    user's longitude
      * @param addressTypes preferred result_types that should be included in the
-     *                    result.
+     *                     result.
      * @return {@link GeocodingResult}
      */
     public GeocodingResult getLocationByCoordinates(Double latitude, Double longitude, String lang,

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package greencity.service;
 
 import com.google.maps.model.AddressComponentType;
+import com.google.maps.model.AddressType;
 import com.google.maps.model.GeocodingResult;
 import greencity.client.RestClient;
 import greencity.constant.ErrorMessage;
@@ -610,14 +611,17 @@ public class UserServiceImpl implements UserService {
             old.getUsers().remove(user);
             user.setUserLocation(null);
         } else {
+            final AddressType[] addressTypes =
+                {AddressType.LOCALITY, AddressType.ADMINISTRATIVE_AREA_LEVEL_1, AddressType.COUNTRY};
+
             GeocodingResult resultsUk = googleApiService.getLocationByCoordinates(
                 userProfileDtoRequest.getCoordinates().getLatitude(),
                 userProfileDtoRequest.getCoordinates().getLongitude(),
-                "uk");
+                "uk", addressTypes);
             GeocodingResult resultsEn = googleApiService.getLocationByCoordinates(
                 userProfileDtoRequest.getCoordinates().getLatitude(),
                 userProfileDtoRequest.getCoordinates().getLongitude(),
-                "en");
+                "en", addressTypes);
             UserLocation userLocation = userLocationRepo.getUserLocationByLatitudeAndLongitude(
                 userProfileDtoRequest.getCoordinates().getLatitude(),
                 userProfileDtoRequest.getCoordinates().getLongitude()).orElse(new UserLocation());
@@ -670,7 +674,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private void checkGeocodingResultContainsAllInformation(GeocodingResult geocodingResult, int size) {
-        if (geocodingResult.addressComponents.length <= size) {
+        if (geocodingResult.addressComponents.length < size) {
             throw new InsufficientLocationDataException(ErrorMessage.INSUFFICIENT_LOCATION_DATA_FOUND);
         }
     }

--- a/service/src/test/java/greencity/service/GoogleApiServiceTest.java
+++ b/service/src/test/java/greencity/service/GoogleApiServiceTest.java
@@ -51,7 +51,7 @@ class GoogleApiServiceTest {
             when(request.await()).thenReturn(ModelUtils.getGeocodingResult().toArray(GeocodingResult[]::new));
             assertDoesNotThrow(
                 () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
-                        addressTypes));
+                    addressTypes));
             verify(request).latlng(coordinates);
             verify(request).language(LANGUAGE_UA);
             verify(request).await();
@@ -73,7 +73,7 @@ class GoogleApiServiceTest {
             NotFoundException exception =
                 assertThrows(NotFoundException.class,
                     () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
-                            addressTypes));
+                        addressTypes));
 
             assertEquals(ErrorMessage.NOT_FOUND_ADDRESS_BY_COORDINATES + formattedCoordinates, exception.getMessage());
             verify(request).language(LANGUAGE_UA);
@@ -96,7 +96,7 @@ class GoogleApiServiceTest {
 
             assertThrows(GoogleApiException.class,
                 () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
-                        addressTypes));
+                    addressTypes));
             verify(request).language(LANGUAGE_UA);
             verify(request).latlng(coordinates);
             verify(request).await();
@@ -120,7 +120,7 @@ class GoogleApiServiceTest {
 
             assertThrows(GoogleApiException.class,
                 () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language,
-                        addressTypes));
+                    addressTypes));
             verify(request).language(language);
             verify(request).latlng(coordinates);
             verify(request).await();

--- a/service/src/test/java/greencity/service/GoogleApiServiceTest.java
+++ b/service/src/test/java/greencity/service/GoogleApiServiceTest.java
@@ -4,6 +4,7 @@ import com.google.maps.GeoApiContext;
 import com.google.maps.GeocodingApi;
 import com.google.maps.GeocodingApiRequest;
 import com.google.maps.errors.InvalidRequestException;
+import com.google.maps.model.AddressType;
 import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import greencity.ModelUtils;
@@ -32,48 +33,50 @@ class GoogleApiServiceTest {
     GeoApiContext context;
     @Mock
     GeocodingApiRequest request;
+    private final AddressType[] addressTypes =
+        {AddressType.LOCALITY, AddressType.ADMINISTRATIVE_AREA_LEVEL_1, AddressType.COUNTRY};
+    final String LANGUAGE_UA = "uk";
+    private final LatLng coordinates = new LatLng(20.000000, 20.000000);
 
     @Test
     @SneakyThrows
-    void testGetLocationByCoordinates() {
-        String language = "uk";
-        LatLng coordinates = new LatLng(20.000000, 20.000000);
+    void getLocationByCoordinatesTest() {
         try (MockedStatic<GeocodingApi> utilities = Mockito.mockStatic(GeocodingApi.class)) {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
             when(request.latlng(coordinates)).thenReturn(request);
-            when(request.language(language)).thenReturn(request);
-            when(request.await()).thenReturn(new GeocodingResult[] {ModelUtils.getGeocodingResult().get(1)});
-
+            when(request.language(LANGUAGE_UA)).thenReturn(request);
+            when(request.resultType(addressTypes)).thenReturn(request);
+            when(request.await()).thenReturn(ModelUtils.getGeocodingResult().toArray(GeocodingResult[]::new));
             assertDoesNotThrow(
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language));
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                        addressTypes));
             verify(request).latlng(coordinates);
-            verify(request).language(language);
+            verify(request).language(LANGUAGE_UA);
             verify(request).await();
         }
     }
 
     @Test
     @SneakyThrows
-    void testGtLocationByCoordinatesThrowsNotFoundException() {
-        String language = "uk";
-        LatLng coordinates = new LatLng(20.000000, 20.000000);
-
+    void getLocationByCoordinatesThrowsNotFoundExceptionTest() {
         try (MockedStatic<GeocodingApi> utilities = Mockito.mockStatic(GeocodingApi.class)) {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
-            when(request.language(language)).thenReturn(request);
+            when(request.language(LANGUAGE_UA)).thenReturn(request);
             when(request.latlng(coordinates)).thenReturn(request);
+            when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new InvalidRequestException("message"));
             String formattedCoordinates = "%.8f,%.8f".formatted(coordinates.lat, coordinates.lng);
             NotFoundException exception =
                 assertThrows(NotFoundException.class,
-                    () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language));
+                    () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                            addressTypes));
 
             assertEquals(ErrorMessage.NOT_FOUND_ADDRESS_BY_COORDINATES + formattedCoordinates, exception.getMessage());
-            verify(request).language(language);
+            verify(request).language(LANGUAGE_UA);
             verify(request).latlng(coordinates);
             verify(request).await();
         }
@@ -81,21 +84,20 @@ class GoogleApiServiceTest {
 
     @Test
     @SneakyThrows
-    void testGetLocationByCoordinatesThrowsGoogleApiException() {
-        String language = "uk";
-        LatLng coordinates = new LatLng(20.000000, 20.000000);
-
+    void getLocationByCoordinatesThrowsGoogleApiExceptionTest() {
         try (MockedStatic<GeocodingApi> utilities = Mockito.mockStatic(GeocodingApi.class)) {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
-            when(request.language(language)).thenReturn(request);
+            when(request.language(LANGUAGE_UA)).thenReturn(request);
+            when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new GoogleApiException("something went wrong"));
             when(request.latlng(coordinates)).thenReturn(request);
 
             assertThrows(GoogleApiException.class,
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language));
-            verify(request).language(language);
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                        addressTypes));
+            verify(request).language(LANGUAGE_UA);
             verify(request).latlng(coordinates);
             verify(request).await();
         }
@@ -103,7 +105,7 @@ class GoogleApiServiceTest {
 
     @Test
     @SneakyThrows
-    void testGetLocationByCoordinatesThrowsInterruptedException() {
+    void getLocationByCoordinatesThrowsInterruptedExceptionTest() {
         String language = "uk";
         LatLng coordinates = new LatLng(20.000000, 20.000000);
 
@@ -112,11 +114,13 @@ class GoogleApiServiceTest {
                 .thenReturn(request);
 
             when(request.language(language)).thenReturn(request);
+            when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new InterruptedException());
             when(request.latlng(coordinates)).thenReturn(request);
 
             assertThrows(GoogleApiException.class,
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language));
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language,
+                        addressTypes));
             verify(request).language(language);
             verify(request).latlng(coordinates);
             verify(request).await();

--- a/service/src/test/java/greencity/service/GoogleApiServiceTest.java
+++ b/service/src/test/java/greencity/service/GoogleApiServiceTest.java
@@ -35,7 +35,7 @@ class GoogleApiServiceTest {
     GeocodingApiRequest request;
     private final AddressType[] addressTypes =
         {AddressType.LOCALITY, AddressType.ADMINISTRATIVE_AREA_LEVEL_1, AddressType.COUNTRY};
-    final String LANGUAGE_UA = "uk";
+    private final String languageUa = "uk";
     private final LatLng coordinates = new LatLng(20.000000, 20.000000);
 
     @Test
@@ -46,14 +46,14 @@ class GoogleApiServiceTest {
                 .thenReturn(request);
 
             when(request.latlng(coordinates)).thenReturn(request);
-            when(request.language(LANGUAGE_UA)).thenReturn(request);
+            when(request.language(languageUa)).thenReturn(request);
             when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenReturn(ModelUtils.getGeocodingResult().toArray(GeocodingResult[]::new));
             assertDoesNotThrow(
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, languageUa,
                     addressTypes));
             verify(request).latlng(coordinates);
-            verify(request).language(LANGUAGE_UA);
+            verify(request).language(languageUa);
             verify(request).await();
         }
     }
@@ -65,18 +65,18 @@ class GoogleApiServiceTest {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
-            when(request.language(LANGUAGE_UA)).thenReturn(request);
+            when(request.language(languageUa)).thenReturn(request);
             when(request.latlng(coordinates)).thenReturn(request);
             when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new InvalidRequestException("message"));
             String formattedCoordinates = "%.8f,%.8f".formatted(coordinates.lat, coordinates.lng);
             NotFoundException exception =
                 assertThrows(NotFoundException.class,
-                    () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                    () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, languageUa,
                         addressTypes));
 
             assertEquals(ErrorMessage.NOT_FOUND_ADDRESS_BY_COORDINATES + formattedCoordinates, exception.getMessage());
-            verify(request).language(LANGUAGE_UA);
+            verify(request).language(languageUa);
             verify(request).latlng(coordinates);
             verify(request).await();
         }
@@ -89,15 +89,15 @@ class GoogleApiServiceTest {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
-            when(request.language(LANGUAGE_UA)).thenReturn(request);
+            when(request.language(languageUa)).thenReturn(request);
             when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new GoogleApiException("something went wrong"));
             when(request.latlng(coordinates)).thenReturn(request);
 
             assertThrows(GoogleApiException.class,
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, LANGUAGE_UA,
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, languageUa,
                     addressTypes));
-            verify(request).language(LANGUAGE_UA);
+            verify(request).language(languageUa);
             verify(request).latlng(coordinates);
             verify(request).await();
         }
@@ -106,22 +106,19 @@ class GoogleApiServiceTest {
     @Test
     @SneakyThrows
     void getLocationByCoordinatesThrowsInterruptedExceptionTest() {
-        String language = "uk";
-        LatLng coordinates = new LatLng(20.000000, 20.000000);
-
         try (MockedStatic<GeocodingApi> utilities = Mockito.mockStatic(GeocodingApi.class)) {
             utilities.when(() -> GeocodingApi.newRequest(context))
                 .thenReturn(request);
 
-            when(request.language(language)).thenReturn(request);
+            when(request.language(languageUa)).thenReturn(request);
             when(request.resultType(addressTypes)).thenReturn(request);
             when(request.await()).thenThrow(new InterruptedException());
             when(request.latlng(coordinates)).thenReturn(request);
 
             assertThrows(GoogleApiException.class,
-                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, language,
+                () -> googleApiService.getLocationByCoordinates(coordinates.lat, coordinates.lng, languageUa,
                     addressTypes));
-            verify(request).language(language);
+            verify(request).language(languageUa);
             verify(request).latlng(coordinates);
             verify(request).await();
         }

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import com.google.maps.model.AddressType;
 import greencity.ModelUtils;
 import greencity.TestConst;
 import greencity.client.RestClient;
@@ -108,6 +109,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -141,6 +143,10 @@ class UserServiceImplTest {
 
     @Mock
     private SimpMessagingTemplate messagingTemplate;
+    private final AddressType[] addressTypes =
+        {AddressType.LOCALITY, AddressType.ADMINISTRATIVE_AREA_LEVEL_1, AddressType.COUNTRY};
+    private final String LANGUAGE_UA = "uk"; // language for GeocodingApi it gets uk not ua.
+    private final String LANGUAGE_EN = "en";
 
     private final User user = User.builder()
         .id(1L)
@@ -620,17 +626,18 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
-        verify(googleApiService, times(2)).getLocationByCoordinates(eq(1.0d), eq(1.0d), anyString());
+        verify(googleApiService, times(2)).getLocationByCoordinates(eq(1.0d), eq(1.0d), anyString(),
+            aryEq(addressTypes));
         verify(userRepo).save(myUser);
     }
 
@@ -642,20 +649,20 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResultWithInsufficientData());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResultWithInsufficientData());
 
         assertThrows(InsufficientLocationDataException.class,
             () -> userService.saveUserProfile(request, "test@gmail.com"));
 
         verify(userRepo).findByEmail("test@gmail.com");
-        verify(googleApiService, times(2)).getLocationByCoordinates(any(), any(), anyString());
+        verify(googleApiService, times(2)).getLocationByCoordinates(any(), any(), anyString(), aryEq(addressTypes));
     }
 
     @Test
@@ -725,7 +732,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    void testUpdateUserProfileLocationWithTwoAssignedUsers() {
+    void updateUserProfileLocationWithTwoAssignedUsersTest() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
         request.setCoordinates(coordinates);
@@ -742,25 +749,26 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
         verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
             request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
         verify(googleApiService, times(2)).getLocationByCoordinates(
-            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString(),
+            aryEq(addressTypes));
         verify(userRepo).save(myUser);
     }
 
     @Test
-    void testUpdateUserProfileLocationWhenUserHasAUserLocation() {
+    void updateUserProfileLocationWhenUserHasAUserLocationTest() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
@@ -778,20 +786,21 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
         verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
             request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
         verify(googleApiService, times(2)).getLocationByCoordinates(
-            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString(),
+            aryEq(addressTypes));
         verify(userLocationRepo).save(userLocation2);
         verify(userRepo).save(myUser);
         verify(userLocationRepo).delete(any());
@@ -812,7 +821,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    void testUpdateUserProfileRemoveUserFromUserLocationList() {
+    void updateUserProfileRemoveUserFromUserLocationListTest() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
@@ -832,13 +841,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         assertEquals(1, myUser.getUserLocation().getUsers().size());
@@ -846,13 +855,14 @@ class UserServiceImplTest {
         verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
             request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
         verify(googleApiService, times(2)).getLocationByCoordinates(
-            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString(),
+            aryEq(addressTypes));
         verify(userLocationRepo).save(userLocation2);
         verify(userRepo).save(myUser);
     }
 
     @Test
-    void testUpdateUserProfileLocationWhenUserModifyUserLocation() {
+    void updateUserProfileLocationWhenUserModifyUserLocationTest() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
@@ -869,20 +879,21 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
         verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
             request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
         verify(googleApiService, times(2)).getLocationByCoordinates(
-            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString(),
+            aryEq(addressTypes));
         verify(userLocationRepo).save(any());
         verify(userRepo).save(myUser);
         verify(userLocationRepo, never()).delete(any());
@@ -899,7 +910,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    void saveUserProfileWhenLocationIsNotUpdated() {
+    void saveUserProfileWhenLocationIsNotUpdatedTest() {
         UserProfileDtoRequest request = new UserProfileDtoRequest();
         request.setName("Dmutro");
         CoordinatesDto coordinates = new CoordinatesDto(20.0000, 20.0000);
@@ -915,13 +926,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "uk"))
+            LANGUAGE_UA, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            "en"))
+            LANGUAGE_EN, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
@@ -929,7 +940,8 @@ class UserServiceImplTest {
         verify(userLocationRepo).getUserLocationByLatitudeAndLongitude(
             request.getCoordinates().getLatitude(), request.getCoordinates().getLongitude());
         verify(googleApiService, times(2)).getLocationByCoordinates(
-            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString());
+            eq(request.getCoordinates().getLatitude()), eq(request.getCoordinates().getLongitude()), anyString(),
+            aryEq(addressTypes));
         verify(userLocationRepo).save(any());
         verify(userRepo).save(myUser);
         verify(userLocationRepo, never()).delete(any());

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -145,8 +145,8 @@ class UserServiceImplTest {
     private SimpMessagingTemplate messagingTemplate;
     private final AddressType[] addressTypes =
         {AddressType.LOCALITY, AddressType.ADMINISTRATIVE_AREA_LEVEL_1, AddressType.COUNTRY};
-    private final String LANGUAGE_UA = "uk"; // language for GeocodingApi it gets uk not ua.
-    private final String LANGUAGE_EN = "en";
+    private final String languageUa = "uk"; // language for GeocodingApi it gets uk not ua.
+    private final String languageEn = "en";
 
     private final User user = User.builder()
         .id(1L)
@@ -626,13 +626,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
@@ -649,13 +649,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResultWithInsufficientData());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResultWithInsufficientData());
 
         assertThrows(InsufficientLocationDataException.class,
@@ -749,13 +749,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
@@ -786,13 +786,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
@@ -841,13 +841,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         assertEquals(1, myUser.getUserLocation().getUsers().size());
@@ -879,13 +879,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));
         verify(userRepo).findByEmail("test@gmail.com");
@@ -926,13 +926,13 @@ class UserServiceImplTest {
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_UA, addressTypes))
+            languageUa, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         when(googleApiService.getLocationByCoordinates(
             request.getCoordinates().getLatitude(),
             request.getCoordinates().getLongitude(),
-            LANGUAGE_EN, addressTypes))
+            languageEn, addressTypes))
                 .thenReturn(ModelUtils.getGeocodingResult().getFirst());
 
         assertEquals(UpdateConstants.SUCCESS_EN, userService.saveUserProfile(request, "test@gmail.com"));


### PR DESCRIPTION
# GreenCity User PR
## Issue Links 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/7946">#7946</a>
<a href="https://github.com/ita-social-projects/GreenCity/issues/7945">#7945</a>

## Changed

- Modified method _getLocationByCoordinates_ in `GoogleApiService` by adding an array of `AddressType` as a parameter and used it as a filter in requests to Google map API;
- Fixed _setLocationForUser_ method in `UserServiceImpl` as it uses _getLocationByCoordinates_ method from `GoogleApiService` which was modified; 
- Refactored tests in `GoogleApiServiceTest` according to changes made in `GoogleApiService`; 
- Renamed modified tests in `GoogleApiServiceTest` and `UserServiceImplTest` according to the new naming convention; 
- Refactored tests in `UserServiceImplTest` according to changes in `UserServiceImpl` and `GoogleApiService` classes;

## Summary Of Changes 🔥
Fixed main functionality for updating location on the edit profile page.
