### PR TITLE
Git commit info endpoint

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
     private final JwtTool jwtTool;
     private final UserService userService;
     private static final String USER_LINK = "/user";
+    private static final String COMMIT_INFO = "/commit-info";
     private final AuthenticationConfiguration authenticationConfiguration;
 
     @Value("${spring.messaging.stomp.websocket.allowed-origins}")
@@ -119,7 +120,8 @@ public class SecurityConfig {
                     "/socket/**",
                     "/user/findAllByEmailNotification",
                     "/user/checkByUuid",
-                    "/user/get-user-rating")
+                    "/user/get-user-rating",
+                    COMMIT_INFO)
                 .permitAll()
                 .requestMatchers(HttpMethod.POST,
                     "/ownSecurity/signUp",

--- a/core/src/main/java/greencity/controller/CommitInfoController.java
+++ b/core/src/main/java/greencity/controller/CommitInfoController.java
@@ -1,0 +1,56 @@
+package greencity.controller;
+
+import greencity.constant.HttpStatuses;
+import greencity.dto.commitinfo.CommitInfoDto;
+import greencity.service.CommitInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for fetching Git commit information.
+ */
+@RestController
+@RequestMapping("/commit-info")
+@RequiredArgsConstructor
+public class CommitInfoController {
+    private final CommitInfoService commitInfoService;
+
+    /**
+     * Endpoint to fetch the latest Git commit hash and date.
+     *
+     * @return {@link CommitInfoDto}
+     */
+    @Operation(summary = "Get the latest commit hash and date.")
+    @ApiResponse(
+        responseCode = "200",
+        description = HttpStatuses.OK,
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(
+                value = """
+                    {
+                        "commitHash": "d6e70c46b39857846f3f13ca9756c39448ab3d6f",
+                        "commitDate": "16/12/2024 10:55:00"
+                    }""")))
+    @ApiResponse(
+        responseCode = "404",
+        description = HttpStatuses.NOT_FOUND,
+        content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(
+                value = """
+                    {
+                        "message": "Git repository not initialized. Commit info is unavailable."
+                    }""")))
+    @GetMapping
+    public ResponseEntity<CommitInfoDto> getCommitInfo() {
+        return ResponseEntity.ok(commitInfoService.getLatestCommitInfo());
+    }
+}

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -21,6 +21,7 @@ import greencity.exception.exceptions.WrongPasswordException;
 import greencity.exception.exceptions.GoogleApiException;
 import greencity.exception.exceptions.UserDeactivationException;
 import greencity.exception.exceptions.Base64DecodedException;
+import greencity.exception.exceptions.ResourceNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Collections;
@@ -488,5 +489,24 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
+    /**
+     * Method intercepts exception {@link ResourceNotFoundException}.
+     *
+     * @param ex      Exception that should be intercepted.
+     * @param request Contains details about the occurred exception.
+     * @return {@code ResponseEntity} which contains the HTTP status and body with
+     *         the exception message.
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public final ResponseEntity<Object> handleResourceNotFoundException(ResourceNotFoundException ex,
+        WebRequest request) {
+        log.error(ex.getMessage(), ex);
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        exceptionResponse.setMessage(ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
     }
 }

--- a/core/src/test/java/greencity/controller/CommitInfoControllerTest.java
+++ b/core/src/test/java/greencity/controller/CommitInfoControllerTest.java
@@ -1,0 +1,65 @@
+package greencity.controller;
+
+import greencity.dto.commitinfo.CommitInfoDto;
+import greencity.exception.exceptions.ResourceNotFoundException;
+import greencity.service.CommitInfoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(MockitoExtension.class)
+class CommitInfoControllerTest {
+    @InjectMocks
+    private CommitInfoController commitInfoController;
+
+    @Mock
+    private CommitInfoService commitInfoService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(commitInfoController).build();
+    }
+
+    private static final String COMMIT_INFO_URL = "/commit-info";
+    private static final String COMMIT_HASH = "abc123";
+    private static final String COMMIT_DATE = "16/12/2024 12:06:32";
+
+    @Test
+    void getCommitInfoReturnsSuccessTest() throws Exception {
+        CommitInfoDto commitInfoDto = new CommitInfoDto(COMMIT_HASH, COMMIT_DATE);
+        when(commitInfoService.getLatestCommitInfo()).thenReturn(commitInfoDto);
+
+        mockMvc.perform(get(COMMIT_INFO_URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.commitHash").value(COMMIT_HASH))
+            .andExpect(jsonPath("$.commitDate").value(COMMIT_DATE));
+
+        verify(commitInfoService, times(1)).getLatestCommitInfo();
+    }
+
+    @Test
+    void getCommitInfoReturnsErrorTest() throws Exception {
+        when(commitInfoService.getLatestCommitInfo()).thenThrow(new ResourceNotFoundException());
+
+        mockMvc.perform(get(COMMIT_INFO_URL))
+            .andExpect(status().isNotFound());
+
+        verify(commitInfoService, times(1)).getLatestCommitInfo();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <checkstyle-maven-plugin.version>3.3.1</checkstyle-maven-plugin.version>
+        <org.eclipse.jgit.version>7.1.0.202411261347-r</org.eclipse.jgit.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -5,6 +5,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class AppConstant {
     public static final String UKRAINE_TIMEZONE = "Europe/Kiev";
+    public static final String DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
     public static final String REGISTRATION_EMAIL_FIELD_NAME = "email";
     public static final String GOOGLE_PICTURE = "picture";
     public static final String ADMIN = "ADMIN";

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -58,4 +58,9 @@ public class ErrorMessage {
     public static final String BRUTEFORCE_PROTECTION_MESSAGE_WRONG_PASS =
         "User account is blocked due to too many failed login attempts. Try again in %s minutes";
     public static final String WRONG_SECRET_KEY = "Wrong secret key";
+    public static final String WARNING_GIT_DIRECTORY_NOT_FOUND =
+        "WARNING: .git directory not found. Git commit info will be unavailable.";
+    public static final String GIT_REPOSITORY_NOT_INITIALIZED =
+        "Git repository not initialized. Commit info is unavailable.";
+    public static final String FAILED_TO_FETCH_COMMIT_INFO = "Failed to fetch commit info due to I/O error: ";
 }

--- a/service-api/src/main/java/greencity/dto/commitinfo/CommitInfoDto.java
+++ b/service-api/src/main/java/greencity/dto/commitinfo/CommitInfoDto.java
@@ -1,0 +1,21 @@
+package greencity.dto.commitinfo;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for commit information response.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CommitInfoDto {
+    @NotNull
+    private String commitHash;
+    @NotNull
+    private String commitDate;
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/ResourceNotFoundException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package greencity.exception.exceptions;
+
+import lombok.experimental.StandardException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@StandardException
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+}

--- a/service-api/src/main/java/greencity/service/CommitInfoService.java
+++ b/service-api/src/main/java/greencity/service/CommitInfoService.java
@@ -1,0 +1,15 @@
+package greencity.service;
+
+import greencity.dto.commitinfo.CommitInfoDto;
+
+/**
+ * Interface for fetching Git commit information.
+ */
+public interface CommitInfoService {
+    /**
+     * Fetches the latest Git commit hash and date.
+     *
+     * @return {@link CommitInfoDto}
+     */
+    CommitInfoDto getLatestCommitInfo();
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -158,5 +158,10 @@
             <artifactId>google-http-client-jackson2</artifactId>
             <version>1.38.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>${org.eclipse.jgit.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/service/src/main/java/greencity/service/CommitInfoServiceImpl.java
+++ b/service/src/main/java/greencity/service/CommitInfoServiceImpl.java
@@ -1,0 +1,67 @@
+package greencity.service;
+
+import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
+import greencity.dto.commitinfo.CommitInfoDto;
+import greencity.exception.exceptions.ResourceNotFoundException;
+import java.io.File;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service implementation for fetching Git commit information.
+ */
+@Service
+@Slf4j
+public class CommitInfoServiceImpl implements CommitInfoService {
+    private Repository repository;
+
+    private static final String COMMIT_REF = "HEAD";
+
+    public CommitInfoServiceImpl() {
+        try {
+            repository = new FileRepositoryBuilder()
+                .setGitDir(new File(".git"))
+                .setMustExist(true)
+                .readEnvironment()
+                .findGitDir()
+                .build();
+        } catch (IOException e) {
+            repository = null;
+            log.warn(ErrorMessage.WARNING_GIT_DIRECTORY_NOT_FOUND);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ResourceNotFoundException if the Git repository cannot be found, is
+     *                                   not initialized, or commit information
+     *                                   cannot be fetched due to an I/O error.
+     */
+    @Override
+    public CommitInfoDto getLatestCommitInfo() {
+        if (repository == null) {
+            throw new ResourceNotFoundException(ErrorMessage.GIT_REPOSITORY_NOT_INITIALIZED);
+        }
+
+        try (RevWalk revWalk = new RevWalk(repository)) {
+            RevCommit latestCommit = revWalk.parseCommit(repository.resolve(COMMIT_REF));
+            String latestCommitHash = latestCommit.name();
+            String latestCommitDate = DateTimeFormatter.ofPattern(AppConstant.DATE_FORMAT)
+                .withZone(ZoneId.of(AppConstant.UKRAINE_TIMEZONE))
+                .format(latestCommit.getAuthorIdent().getWhenAsInstant());
+
+            return new CommitInfoDto(latestCommitHash, latestCommitDate);
+        } catch (IOException e) {
+            throw new ResourceNotFoundException(ErrorMessage.FAILED_TO_FETCH_COMMIT_INFO + e.getMessage());
+        }
+    }
+}

--- a/service/src/test/java/greencity/service/CommitInfoServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CommitInfoServiceImplTest.java
@@ -1,0 +1,160 @@
+package greencity.service;
+
+import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
+import greencity.dto.commitinfo.CommitInfoDto;
+import greencity.exception.exceptions.ResourceNotFoundException;
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommitInfoServiceImplTest {
+    @InjectMocks
+    private CommitInfoServiceImpl commitInfoService;
+
+    @Mock
+    private Repository repository;
+
+    @Mock
+    private RevCommit revCommit;
+
+    @Mock
+    private ObjectId objectId;
+
+    @Mock
+    private PersonIdent personIdent;
+
+    private static final String COMMIT_HASH = "abc123";
+    private static final String COMMIT_REF = "HEAD";
+    private static final String GIT_PATH = ".git";
+    private static final String REPOSITORY_FIELD = "repository";
+
+    private void configureFileRepositoryBuilderMock(FileRepositoryBuilder builderMock) {
+        when(builderMock.setGitDir(new File(GIT_PATH))).thenReturn(builderMock);
+        when(builderMock.setMustExist(true)).thenReturn(builderMock);
+        when(builderMock.readEnvironment()).thenReturn(builderMock);
+        when(builderMock.findGitDir()).thenReturn(builderMock);
+    }
+
+    @Test
+    void constructorInitializationSuccessTest() throws NoSuchFieldException, IllegalAccessException {
+        try (MockedConstruction<FileRepositoryBuilder> ignored = mockConstruction(FileRepositoryBuilder.class,
+            (builderMock, context) -> {
+                configureFileRepositoryBuilderMock(builderMock);
+                when(builderMock.build()).thenReturn(repository);
+            })) {
+            CommitInfoServiceImpl service = new CommitInfoServiceImpl();
+
+            var repositoryField = CommitInfoServiceImpl.class.getDeclaredField(REPOSITORY_FIELD);
+            repositoryField.setAccessible(true);
+            Repository initializedRepository = (Repository) repositoryField.get(service);
+
+            assertNotNull(initializedRepository);
+        }
+    }
+
+    @Test
+    void constructorInitializationFailureTest() throws NoSuchFieldException, IllegalAccessException {
+        try (MockedConstruction<FileRepositoryBuilder> ignored = mockConstruction(FileRepositoryBuilder.class,
+            (builderMock, context) -> {
+                configureFileRepositoryBuilderMock(builderMock);
+                when(builderMock.build()).thenThrow(new IOException());
+            })) {
+            CommitInfoServiceImpl service = new CommitInfoServiceImpl();
+
+            var repositoryField = CommitInfoServiceImpl.class.getDeclaredField(REPOSITORY_FIELD);
+            repositoryField.setAccessible(true);
+            Repository initializedRepository = (Repository) repositoryField.get(service);
+
+            assertNull(initializedRepository);
+        }
+    }
+
+    @Test
+    void getLatestCommitInfoWhenRepositoryNotInitializedThrowsNotFoundExceptionTest() {
+        try (MockedConstruction<FileRepositoryBuilder> ignored = mockConstruction(FileRepositoryBuilder.class,
+            (builderMock, context) -> {
+                configureFileRepositoryBuilderMock(builderMock);
+                when(builderMock.build()).thenThrow(new IOException());
+            })) {
+            CommitInfoServiceImpl service = new CommitInfoServiceImpl();
+            ResourceNotFoundException notFoundException =
+                assertThrows(ResourceNotFoundException.class, service::getLatestCommitInfo);
+
+            assertEquals(ErrorMessage.GIT_REPOSITORY_NOT_INITIALIZED, notFoundException.getMessage());
+        }
+    }
+
+    @Test
+    void getLatestCommitInfoWithValidDataReturnsSuccessDtoTest() throws IOException {
+        when(repository.resolve(COMMIT_REF)).thenReturn(objectId);
+        when(revCommit.name()).thenReturn(COMMIT_HASH);
+        when(revCommit.getAuthorIdent()).thenReturn(personIdent);
+
+        Instant expectedDate = Instant.parse("2024-12-14T16:30:00Z");
+        when(personIdent.getWhenAsInstant()).thenReturn(expectedDate);
+
+        try (
+            MockedConstruction<RevWalk> ignored = mockConstruction(RevWalk.class,
+                (revWalkMock, context) -> when(revWalkMock.parseCommit(objectId)).thenReturn(revCommit))) {
+            CommitInfoDto actualDto = commitInfoService.getLatestCommitInfo();
+
+            assertEquals(COMMIT_HASH, actualDto.getCommitHash());
+
+            String latestCommitDate = DateTimeFormatter.ofPattern(AppConstant.DATE_FORMAT)
+                .withZone(ZoneId.of(AppConstant.UKRAINE_TIMEZONE))
+                .format(expectedDate);
+            assertEquals(latestCommitDate, actualDto.getCommitDate());
+        }
+    }
+
+    @Test
+    void getLatestCommitInfoWhenRepositoryResolveThrowsIOExceptionReturnsErrorDtoTest() throws IOException {
+        String testExceptionMessage = "Test I/O exception";
+        when(repository.resolve(COMMIT_REF)).thenThrow(new IOException(testExceptionMessage));
+
+        ResourceNotFoundException notFoundException =
+            assertThrows(ResourceNotFoundException.class, () -> commitInfoService.getLatestCommitInfo());
+
+        assertEquals(ErrorMessage.FAILED_TO_FETCH_COMMIT_INFO + testExceptionMessage, notFoundException.getMessage());
+    }
+
+    @Test
+    void getLatestCommitInfoWhenRevWalkParseCommitThrowsIOExceptionReturnsErrorDtoTest() throws IOException {
+        String missingObjectMessage = "Missing object";
+        when(repository.resolve(COMMIT_REF)).thenReturn(objectId);
+
+        try (
+            MockedConstruction<RevWalk> ignored = mockConstruction(RevWalk.class,
+                (revWalkMock, context) -> when(revWalkMock.parseCommit(objectId)).thenThrow(
+                    new IOException(missingObjectMessage)))) {
+            ResourceNotFoundException notFoundException =
+                assertThrows(ResourceNotFoundException.class, () -> commitInfoService.getLatestCommitInfo());
+
+            assertEquals(ErrorMessage.FAILED_TO_FETCH_COMMIT_INFO + missingObjectMessage,
+                notFoundException.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
#7929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new endpoint `/commit-info` to retrieve the latest Git commit information
  - Introduced ability to fetch and display commit hash and date

- **Bug Fixes**
  - Enhanced error handling for scenarios where Git repository is not initialized

- **Documentation**
  - Improved API documentation for commit information retrieval

- **Security**
  - Updated security configuration to allow access to the new commit information endpoint

The release adds a new feature to display the latest Git commit details, providing more transparency about the current application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->