### PR TITLE
Remove from API documentation has an extra invalid option for the request body 

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -319,7 +319,7 @@ public class UserController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
-    @PatchMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
         path = "/profilePicture")
     public ResponseEntity<HttpStatus> updateUserProfilePicture(
         @Parameter(description = "pass image as base64") @ValidBase64 @RequestPart(required = false) String base64,

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -313,8 +313,8 @@ class UserControllerTest {
             .file(jsonFile)
             .headers(headers)
             .principal(principal)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON))
+            .accept(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
             .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
😎GreenCityUser PR 😎

Issue Link:
[8018](https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=assignee%3ACr1stal423&pane=issue&itemId=93414677&issue=ita-social-projects%7CGreenCity%7C8018)
Changes:

Remove invalid option from request body
Fix related test

Previous Condition:

![image](https://github.com/user-attachments/assets/32992c06-a4a9-409a-864f-94ec084d71f6)

Current Condition:

![image](https://github.com/user-attachments/assets/4fee05e1-0902-4352-ae82-a70b363b6637)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated profile picture upload endpoint to exclusively support multipart form data

- **Bug Fixes**
	- Refined content type handling for user profile picture updates to improve request compatibility

- **Tests**
	- Updated test cases to align with new multipart form data requirements for profile picture uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->