### PR TITLE
Use DELETE method for removing UserProfilePicture instead of PATСH

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -67,6 +67,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -340,7 +341,7 @@ public class UserController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
-    @PatchMapping(path = "/deleteProfilePicture")
+    @DeleteMapping(path = "/deleteProfilePicture")
     public ResponseEntity<HttpStatus> deleteUserProfilePicture(Principal principal) {
         userService.deleteUserProfilePicture(principal.getName());
         return ResponseEntity.ok().build();

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -60,6 +60,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -322,7 +324,7 @@ class UserControllerTest {
     void deleteUserProfilePictureTest() throws Exception {
         Principal principal = mock(Principal.class);
         when(principal.getName()).thenReturn("test@email.com");
-        mockMvc.perform(patch(userLink + "/deleteProfilePicture")
+        mockMvc.perform(delete(userLink + "/deleteProfilePicture")
             .principal(principal))
             .andExpect(status().isOk());
 


### PR DESCRIPTION
😎 GreenCity User 😎

Issue Link:
[8019](https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=assignee%3ACr1stal423&pane=issue&itemId=93418826&issue=ita-social-projects%7CGreenCity%7C8019)
Changes:

Replace PATH with DELETE mapping 
Fix the related test  

Previous Condition:

![image](https://github.com/user-attachments/assets/d1621568-8302-45eb-9383-ad6f0e30e414)

Current Condition:

![image](https://github.com/user-attachments/assets/4d842a44-a7af-42dd-99f9-c7e04d58325b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user profile picture deletion endpoint to use the correct HTTP DELETE method

- **Bug Fixes**
	- Corrected HTTP method for profile picture deletion to align with RESTful API best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->