### PR TITLE
8277/add external dependency greencity user dev

### DIFF
--- a/az-cd-pipeline.yml
+++ b/az-cd-pipeline.yml
@@ -48,6 +48,25 @@ stages:
         KeyVaultName: '$(azKeyVault)'
         SecretsFilter: 'ftpHost, ftpUser, ftpPass'
 
+    - task: AzureKeyVault@1
+      inputs:
+        azureSubscription: '$(azureSub)'
+        KeyVaultName: 'greencity-app'
+        SecretsFilter: 'LOGGING-ITA-TOKEN'
+        RunAsPreJob: false
+
+    - script: |
+        echo "<settings>" > $(Build.SourcesDirectory)/settings.xml
+        echo "  <servers>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "    <server>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <id>github</id>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <username>ita-social-projects</username>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "      <password>$(LOGGING-ITA-TOKEN)</password>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "    </server>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "  </servers>" >> $(Build.SourcesDirectory)/settings.xml
+        echo "</settings>" >> $(Build.SourcesDirectory)/settings.xml
+        displayName: "Create temporary settings.xml"
+
     - task: Maven@3
       displayName: Maven package
       inputs:
@@ -55,10 +74,14 @@ stages:
         javaHomeOption: 'JDKVersion'
         jdkVersionOption: '1.21'
         mavenVersionOption: 'Default'
-        options: '-Dmaven.test.skip=true'
+        options: '-Dmaven.test.skip=true -s $(Build.SourcesDirectory)/settings.xml'
         
     - script: mv $(userRepoName)/target/*.jar $(userRepoName)/target/$(onbootJarName)
       displayName: Rename user jar to app
+
+    - script: |
+        rm -f $(Build.SourcesDirectory)/settings.xml
+        displayName: "Delete temporary settings.xml"
 
     - task: CopyFiles@2
       displayName: Copy Files

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,16 @@
         <jjwt.version>0.12.3</jjwt.version>
         <modelmapper.version>3.2.0</modelmapper.version>
         <mockito-junit-jupiter.version>3.3.3</mockito-junit-jupiter.version>
+        <ldm.version>0.21.8-SNAPSHOT</ldm.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Repository</name>
+            <url>https://maven.pkg.github.com/Warded120/LDM-spring-boot-starter</url>
+        </repository>
+    </repositories>
 
     <artifactId>core</artifactId>
     <dependencies>
@@ -198,6 +207,11 @@
             <artifactId>spring-cloud-dependencies</artifactId>
             <version>2023.0.3</version>
             <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>com.ivan.softserve</groupId>
+            <artifactId>ldm-spring-boot-starter</artifactId>
+            <version>${ldm.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Part of task [#8277](https://github.com/ita-social-projects/GreenCity/issues/8277)

Most likely, it will not deploy now, but we need this to be in the dev brunch before we add the needed access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a new library to enhance core module functionality.
- **Chores**
  - Improved build pipeline to securely access private dependencies during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->