### PR TITLE
8360/Allow username to start with a lowercase letter

### DIFF
--- a/service-api/src/main/java/greencity/constant/ValidationConstants.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstants.java
@@ -22,7 +22,7 @@ public class ValidationConstants {
     public static final int PLACE_NAME_MAX_LENGTH = 30;
     public static final String USERNAME_REGEXP = """
         ^(?!.*\\.\\.)(?!.*\\.$)(?!.*\\-\\-)\
-        (?=[ЄІЇҐЁА-ЯA-Z])\
+        (?=[ЄІЇҐЁєіїґёА-Яа-яA-Za-z])\
         [ЄІЇҐЁєіїґёА-Яа-яA-Za-z0-9\\s\\-'\\"’.ʼ]\
         {1,30}\
         (?<![ЭэЁёъЪЫы])$\

--- a/service-api/src/main/java/greencity/constant/ValidationConstants.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstants.java
@@ -7,7 +7,7 @@ public class ValidationConstants {
     public static final String EMAIL_REGEXP = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
     public static final String INVALID_EMAIL = "{greenCity.validation.invalid.email}";
     public static final String USERNAME_MESSAGE = """
-        Name must start with a capital letter, \
+        Name must start with a letter, \
         cannot end with dot \
         or contain 2 consecutive dots, dashes and special symbols. \
         Use English or Ukrainian letters, \

--- a/service-api/src/test/java/greencity/security/jwt/dto/ownsecurity/OwnSignUpDtoTest.java
+++ b/service-api/src/test/java/greencity/security/jwt/dto/ownsecurity/OwnSignUpDtoTest.java
@@ -86,7 +86,8 @@ class OwnSignUpDtoTest {
             Arguments.of("User123"),
             Arguments.of("Імʼя2Тест"),
             Arguments.of("ТестʼІмʼя"),
-            Arguments.of("Євген.Тест"));
+            Arguments.of("Євген.Тест"),
+            Arguments.of("lowercase-name"));
     }
 
     private static Stream<Arguments> provideFieldsAndInvalidValues() {
@@ -100,6 +101,7 @@ class OwnSignUpDtoTest {
             Arguments.of("--"),
             Arguments.of("..Тест"),
             Arguments.of("Тест.."),
+            Arguments.of("тест.."),
             Arguments.of("Тест..Імʼя"),
             Arguments.of("Тест--Імʼя"),
             Arguments.of("Тест.."),


### PR DESCRIPTION
# GreenCityUser PR
[Board](https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=8360&pane=issue&itemId=108108426&issue=ita-social-projects%7CGreenCity%7C8360)

## Summary Of Changes :fire:
Allowed username to start with a lowercase letter 

## Issue Link :clipboard:
[#8360](https://github.com/ita-social-projects/GreenCity/issues/8360)

## Changed
The part of the username regex that required first letter to be upper case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Usernames can now start with lowercase Cyrillic and Latin letters, in addition to uppercase letters.

- **Tests**
  - Expanded test coverage for username validation to include lowercase names and additional invalid cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->