### PR TITLE
8321/reduce amount of remote calls

### DIFF
--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -150,6 +150,7 @@ public class GreenCityRemoteClient {
      * @param userId id of the user
      * @return {@link UserLocationDto}.
      */
+    // TODO: seems like it is no longer used
     public Optional<UserLocationDto> findUserLocationByUserId(Long userId) {
         String path = "/users/{userId}/location";
 
@@ -307,9 +308,16 @@ public class GreenCityRemoteClient {
             .block();
     }
 
-    // TODO
     public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfilesByUserIds(List<Long> userIds) {
-        return List.of();
+        String path = "/users/profiles";
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder.path(path)
+                        .queryParam("userIds", userIds)
+                        .build())
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<GreenCityUserProfileDtoResponse>>() {})
+                .block();
     }
 
     public GreenCityUserProfileDtoResponse findGreenCityUserProfileByUserId(Long userId) {

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -25,7 +25,6 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -309,12 +308,12 @@ public class GreenCityRemoteClient {
     }
 
     // TODO
-    public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfileDtoResponseByUserIds(List<Long> userIds) {
+    public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfilesByUserIds(List<Long> userIds) {
         return List.of();
     }
 
-    public GreenCityUserProfileDtoResponse findGreenCityUserProfileDtoResponseByUserId(Long userId) {
-        var greenCityUserProfiles = findGreenCityUserProfileDtoResponseByUserIds(List.of(userId));
+    public GreenCityUserProfileDtoResponse findGreenCityUserProfileByUserId(Long userId) {
+        var greenCityUserProfiles = findGreenCityUserProfilesByUserIds(List.of(userId));
         return greenCityUserProfiles.getFirst();
     }
 

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -2,6 +2,7 @@ package greencity.client;
 
 import greencity.dto.achievement.AchievementVO;
 import greencity.dto.achievement.UserAchievementVO;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UpdateUserCredoDto;
 import greencity.dto.user.CreateGreenCityUserDto;
 import greencity.dto.user.UserAddRatingDto;
@@ -344,6 +345,11 @@ public class GreenCityRemoteClient {
             .retrieve()
             .bodyToMono(Void.class)
             .block();
+    }
+
+    // TODO
+    public GreenCityUserProfileDtoResponse findGreenCityUserProfileDtoResponseByUserId(Long userId) {
+        return null;
     }
 
     private BodyInserters.MultipartInserter multipartInserter(MultipartFile... multipartFiles) {

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -253,17 +253,6 @@ public class GreenCityRemoteClient {
             .block();
     }
 
-    public Double findUserRatingByUserId(Long userId) {
-        String path = "/users/{userId}/rating";
-
-        return webClient.get()
-            .uri(uriBuilder -> uriBuilder.path(path)
-                .build(userId))
-            .retrieve()
-            .bodyToMono(Double.class)
-            .block();
-    }
-
     /**
      * Update user credo by user id.
      *
@@ -282,17 +271,6 @@ public class GreenCityRemoteClient {
             .block();
     }
 
-    public String findUserCredoByUserId(Long userId) {
-        String path = "/users/{userId}/credo";
-
-        return webClient.get()
-            .uri(uriBuilder -> uriBuilder.path(path)
-                .build(userId))
-            .retrieve()
-            .bodyToMono(String.class)
-            .block();
-    }
-
     public boolean createUser(CreateGreenCityUserDto createUserDto) {
         String path = "/users/create";
 
@@ -302,24 +280,6 @@ public class GreenCityRemoteClient {
             .retrieve()
             .bodyToMono(Boolean.class)
             .block());
-    }
-
-    /**
-     * Method to get user's picture path.
-     *
-     * @param userId {@link Long} user's id.
-     * @return {@link String} user's profilePicturePath
-     */
-    public String getUserPicturePath(Long userId) {
-        String path = "/users/picturePath";
-
-        return webClient.get()
-            .uri(uriBuilder -> uriBuilder.path(path)
-                .queryParam(USER_ID_QUERY_PARAM, userId)
-                .build())
-            .retrieve()
-            .bodyToMono(String.class)
-            .block();
     }
 
     public void updateUserPicturePath(Long userId, String profilePicturePath) {
@@ -348,6 +308,10 @@ public class GreenCityRemoteClient {
     }
 
     // TODO
+    public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfileDtoResponseByUserIds(List<Long> userIds) {
+
+    }
+
     public GreenCityUserProfileDtoResponse findGreenCityUserProfileDtoResponseByUserId(Long userId) {
         return null;
     }

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -309,11 +310,12 @@ public class GreenCityRemoteClient {
 
     // TODO
     public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfileDtoResponseByUserIds(List<Long> userIds) {
-
+        return List.of();
     }
 
     public GreenCityUserProfileDtoResponse findGreenCityUserProfileDtoResponseByUserId(Long userId) {
-        return null;
+        var greenCityUserProfiles = findGreenCityUserProfileDtoResponseByUserIds(List.of(userId));
+        return greenCityUserProfiles.getFirst();
     }
 
     private BodyInserters.MultipartInserter multipartInserter(MultipartFile... multipartFiles) {

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -180,7 +180,7 @@ public class GreenCityRemoteClient {
             .bodyValue(userProfileDtoRequest)
             .retrieve()
             .bodyToMono(Void.class)
-            .block();
+            .subscribe();
     }
 
     /**
@@ -269,7 +269,7 @@ public class GreenCityRemoteClient {
             .bodyValue(updateUserCredoDto)
             .retrieve()
             .bodyToMono(Void.class)
-            .block();
+            .subscribe();
     }
 
     public boolean createUser(CreateGreenCityUserDto createUserDto) {
@@ -305,7 +305,7 @@ public class GreenCityRemoteClient {
                 .build(userId))
             .retrieve()
             .bodyToMono(Void.class)
-            .block();
+            .subscribe();
     }
 
     public List<GreenCityUserProfileDtoResponse> findGreenCityUserProfilesByUserIds(List<Long> userIds) {

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -312,12 +312,13 @@ public class GreenCityRemoteClient {
         String path = "/users/profiles";
 
         return webClient.get()
-                .uri(uriBuilder -> uriBuilder.path(path)
-                        .queryParam("userIds", userIds)
-                        .build())
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<List<GreenCityUserProfileDtoResponse>>() {})
-                .block();
+            .uri(uriBuilder -> uriBuilder.path(path)
+                .queryParam("userIds", userIds)
+                .build())
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<List<GreenCityUserProfileDtoResponse>>() {
+            })
+            .block();
     }
 
     public GreenCityUserProfileDtoResponse findGreenCityUserProfileByUserId(Long userId) {

--- a/service-api/src/main/java/greencity/dto/user/GreenCityUserProfileDtoResponse.java
+++ b/service-api/src/main/java/greencity/dto/user/GreenCityUserProfileDtoResponse.java
@@ -1,10 +1,9 @@
 package greencity.dto.user;
 
 public record GreenCityUserProfileDtoResponse(
-        Long userId,
-        String profilePicturePath,
-        String userCredo,
-        Double userRating,
-        UserLocationDto userLocationDto
-) {
+    Long userId,
+    String profilePicturePath,
+    String userCredo,
+    Double userRating,
+    UserLocationDto userLocationDto) {
 }

--- a/service-api/src/main/java/greencity/dto/user/GreenCityUserProfileDtoResponse.java
+++ b/service-api/src/main/java/greencity/dto/user/GreenCityUserProfileDtoResponse.java
@@ -1,0 +1,10 @@
+package greencity.dto.user;
+
+public record GreenCityUserProfileDtoResponse(
+        Long userId,
+        String profilePicturePath,
+        String userCredo,
+        Double userRating,
+        UserLocationDto userLocationDto
+) {
+}

--- a/service/src/main/java/greencity/mapping/UserForListDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/UserForListDtoMapper.java
@@ -1,7 +1,6 @@
 package greencity.mapping;
 
 import greencity.client.GreenCityRemoteClient;
-import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserForListDto;
 import greencity.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,7 @@ public class UserForListDtoMapper extends AbstractConverter<User, UserForListDto
     @Override
     protected UserForListDto convert(User user) {
         Long userId = user.getId();
-        var greenCityUserProfile = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(userId);
+        var greenCityUserProfile = greenCityRemoteClient.findGreenCityUserProfileByUserId(userId);
 
         return UserForListDto.builder()
             .id(userId)

--- a/service/src/main/java/greencity/mapping/UserForListDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/UserForListDtoMapper.java
@@ -1,6 +1,7 @@
 package greencity.mapping;
 
 import greencity.client.GreenCityRemoteClient;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserForListDto;
 import greencity.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ public class UserForListDtoMapper extends AbstractConverter<User, UserForListDto
     @Override
     protected UserForListDto convert(User user) {
         Long userId = user.getId();
+        var greenCityUserProfile = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(userId);
 
         return UserForListDto.builder()
             .id(userId)
@@ -23,7 +25,7 @@ public class UserForListDtoMapper extends AbstractConverter<User, UserForListDto
             .email(user.getEmail())
             .userStatus(user.getUserStatus())
             .role(user.getRole())
-            .userCredo(greenCityRemoteClient.findUserCredoByUserId(userId))
+            .userCredo(greenCityUserProfile.userCredo())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/UserProfileDtoResponseMapper.java
+++ b/service/src/main/java/greencity/mapping/UserProfileDtoResponseMapper.java
@@ -2,6 +2,7 @@ package greencity.mapping;
 
 import greencity.client.GreenCityRemoteClient;
 import greencity.dto.socialnetwork.SocialNetworkResponseDTO;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserNotificationPreferenceDto;
 import greencity.dto.user.UserProfileDtoResponse;
 import greencity.entity.User;
@@ -27,7 +28,7 @@ public class UserProfileDtoResponseMapper extends AbstractConverter<User, UserPr
     @Override
     protected UserProfileDtoResponse convert(User user) {
         Long userId = user.getId();
-        String profilePicture = greenCityRemoteClient.getUserPicturePath(userId);
+        var greenCityUserProfileDtoResponse = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(userId);
 
         List<SocialNetworkResponseDTO> socialNetworks = user.getSocialNetworks().stream()
             .map(socialNetwork -> modelMapper.map(socialNetwork, SocialNetworkResponseDTO.class))
@@ -39,16 +40,16 @@ public class UserProfileDtoResponseMapper extends AbstractConverter<User, UserPr
             .collect(Collectors.toSet());
 
         return UserProfileDtoResponse.builder()
-            .profilePicturePath(profilePicture)
+            .profilePicturePath(greenCityUserProfileDtoResponse.profilePicturePath())
             .name(user.getName())
-            .userCredo(greenCityRemoteClient.findUserCredoByUserId(userId))
+            .userCredo(greenCityUserProfileDtoResponse.userCredo())
             .socialNetworks(socialNetworks)
             .showLocation(user.getShowLocation())
             .showEcoPlace(user.getShowEcoPlace())
             .showToDoList(user.getShowToDoList())
-            .rating(greenCityRemoteClient.findUserRatingByUserId(userId))
+            .rating(greenCityUserProfileDtoResponse.userRating())
             .role(user.getRole())
-            .userLocationDto(greenCityRemoteClient.findUserLocationByUserId(userId).orElse(null))
+            .userLocationDto(greenCityUserProfileDtoResponse.userLocationDto())
             .notificationPreferences(userNotificationPreferences)
             .build();
     }

--- a/service/src/main/java/greencity/mapping/UserProfileDtoResponseMapper.java
+++ b/service/src/main/java/greencity/mapping/UserProfileDtoResponseMapper.java
@@ -2,7 +2,6 @@ package greencity.mapping;
 
 import greencity.client.GreenCityRemoteClient;
 import greencity.dto.socialnetwork.SocialNetworkResponseDTO;
-import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserNotificationPreferenceDto;
 import greencity.dto.user.UserProfileDtoResponse;
 import greencity.entity.User;
@@ -28,7 +27,7 @@ public class UserProfileDtoResponseMapper extends AbstractConverter<User, UserPr
     @Override
     protected UserProfileDtoResponse convert(User user) {
         Long userId = user.getId();
-        var greenCityUserProfileDtoResponse = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(userId);
+        var greenCityUserProfileDtoResponse = greenCityRemoteClient.findGreenCityUserProfileByUserId(userId);
 
         List<SocialNetworkResponseDTO> socialNetworks = user.getSocialNetworks().stream()
             .map(socialNetwork -> modelMapper.map(socialNetwork, SocialNetworkResponseDTO.class))

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -968,7 +968,10 @@ public class UserServiceImpl implements UserService {
                 }.getType());
         allFriends.forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), userId)));
         // This line has to be improved by one call to greenCityRemoteClient
-        allFriends.forEach(f -> f.setProfilePicturePath(greenCityRemoteClient.getUserPicturePath(f.getId())));
+        allFriends.forEach(f -> {
+            var greencityUserProfile = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(f.getId());
+            f.setProfilePicturePath(greencityUserProfile.profilePicturePath());
+        });
         return new PageableDto<>(
             allUsersMutualFriendsRecommendedOrRequest(userId, allFriends),
             allUsers.getTotalElements(),

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -971,10 +971,9 @@ public class UserServiceImpl implements UserService {
         List<Long> allFriendIds = allFriends.stream().map(UserAllFriendsDto::getId).toList();
         var allFriendGreenCityProfiles = greenCityRemoteClient.findGreenCityUserProfilesByUserIds(allFriendIds);
         Map<Long, String> userIdToProfilePictureMap = allFriendGreenCityProfiles.stream()
-                .collect(Collectors.toMap(
-                        GreenCityUserProfileDtoResponse::userId,
-                        GreenCityUserProfileDtoResponse::profilePicturePath
-                ));
+            .collect(Collectors.toMap(
+                GreenCityUserProfileDtoResponse::userId,
+                GreenCityUserProfileDtoResponse::profilePicturePath));
         allFriends.forEach(f -> {
             String profilePicturePath = userIdToProfilePictureMap.get(f.getId());
             f.setProfilePicturePath(profilePicturePath);

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -969,7 +969,7 @@ public class UserServiceImpl implements UserService {
                 }.getType());
         allFriends.forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), userId)));
         List<Long> allFriendIds = allFriends.stream().map(UserAllFriendsDto::getId).toList();
-        var allFriendGreenCityProfiles = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserIds(allFriendIds);
+        var allFriendGreenCityProfiles = greenCityRemoteClient.findGreenCityUserProfilesByUserIds(allFriendIds);
         Map<Long, String> userIdToProfilePictureMap = allFriendGreenCityProfiles.stream()
                 .collect(Collectors.toMap(
                         GreenCityUserProfileDtoResponse::userId,

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -13,6 +13,7 @@ import greencity.dto.filter.FilterUserDto;
 import greencity.dto.todolist.CustomToDoListItemResponseDto;
 import greencity.dto.ubs.UbsTableCreationDto;
 import greencity.dto.user.DeactivateUserRequestDto;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.RoleDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserAddRatingDto;
@@ -967,10 +968,16 @@ public class UserServiceImpl implements UserService {
                 new TypeToken<List<UserAllFriendsDto>>() {
                 }.getType());
         allFriends.forEach(f -> f.setFriendsChatDto(restClient.chatBetweenTwo(f.getId(), userId)));
-        // This line has to be improved by one call to greenCityRemoteClient
+        List<Long> allFriendIds = allFriends.stream().map(UserAllFriendsDto::getId).toList();
+        var allFriendGreenCityProfiles = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserIds(allFriendIds);
+        Map<Long, String> userIdToProfilePictureMap = allFriendGreenCityProfiles.stream()
+                .collect(Collectors.toMap(
+                        GreenCityUserProfileDtoResponse::userId,
+                        GreenCityUserProfileDtoResponse::profilePicturePath
+                ));
         allFriends.forEach(f -> {
-            var greencityUserProfile = greenCityRemoteClient.findGreenCityUserProfileDtoResponseByUserId(f.getId());
-            f.setProfilePicturePath(greencityUserProfile.profilePicturePath());
+            String profilePicturePath = userIdToProfilePictureMap.get(f.getId());
+            f.setProfilePicturePath(profilePicturePath);
         });
         return new PageableDto<>(
             allUsersMutualFriendsRecommendedOrRequest(userId, allFriends),

--- a/service/src/test/java/greencity/mapping/UserForListDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/UserForListDtoMapperTest.java
@@ -30,8 +30,9 @@ class UserForListDtoMapperTest {
         User user = ModelUtils.getUser();
         Long userId = user.getId();
         String userCredo = TestConst.CREDO;
+        String profilePicturePath = "profilePicturePath";
         var greenCityUserProfile =
-            new GreenCityUserProfileDtoResponse(userId, "pfp", userCredo, 0., new UserLocationDto());
+            new GreenCityUserProfileDtoResponse(userId, profilePicturePath, userCredo, 0., new UserLocationDto());
 
         UserForListDto expectedResult = UserForListDto.builder()
             .id(userId)

--- a/service/src/test/java/greencity/mapping/UserForListDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/UserForListDtoMapperTest.java
@@ -3,7 +3,9 @@ package greencity.mapping;
 import greencity.ModelUtils;
 import greencity.TestConst;
 import greencity.client.GreenCityRemoteClient;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserForListDto;
+import greencity.dto.user.UserLocationDto;
 import greencity.entity.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +30,9 @@ class UserForListDtoMapperTest {
         User user = ModelUtils.getUser();
         Long userId = user.getId();
         String userCredo = TestConst.CREDO;
+        var greenCityUserProfile =
+            new GreenCityUserProfileDtoResponse(userId, "pfp", userCredo, 0., new UserLocationDto());
+
         UserForListDto expectedResult = UserForListDto.builder()
             .id(userId)
             .name(user.getName())
@@ -38,8 +43,8 @@ class UserForListDtoMapperTest {
             .userCredo(userCredo)
             .build();
 
-        when(greenCityRemoteClient.findUserCredoByUserId(userId))
-            .thenReturn(userCredo);
+        when(greenCityRemoteClient.findGreenCityUserProfileByUserId(userId))
+            .thenReturn(greenCityUserProfile);
 
         UserForListDto actualResult = userForListDtoMapper.convert(user);
 

--- a/service/src/test/java/greencity/mapping/UserProfileDtoResponseMapperTest.java
+++ b/service/src/test/java/greencity/mapping/UserProfileDtoResponseMapperTest.java
@@ -4,6 +4,7 @@ import greencity.ModelUtils;
 import greencity.TestConst;
 import greencity.client.GreenCityRemoteClient;
 import greencity.dto.socialnetwork.SocialNetworkResponseDTO;
+import greencity.dto.user.GreenCityUserProfileDtoResponse;
 import greencity.dto.user.UserLocationDto;
 import greencity.dto.user.UserNotificationPreferenceDto;
 import greencity.dto.user.UserProfileDtoResponse;
@@ -44,16 +45,19 @@ class UserProfileDtoResponseMapperTest {
         Long userId = user.getId();
         String userCredo = TestConst.CREDO;
         Double userRating = 4.;
+        String profilePicturePath = "http://testpicture.com.ua";
         UserLocationDto userLocationDto = new UserLocationDto();
         SocialNetworkResponseDTO socialNetworkResponseDTO = new SocialNetworkResponseDTO();
         List<SocialNetworkResponseDTO> expectedSocialNetworks = List.of(socialNetworkResponseDTO);
         UserNotificationPreferenceDto userNotificationPreferenceDto = new UserNotificationPreferenceDto();
         Set<UserNotificationPreferenceDto> expectedNotificationPreferences = Set.of(userNotificationPreferenceDto);
+        var greenCityUserProfile =
+            new GreenCityUserProfileDtoResponse(userId, profilePicturePath, userCredo, userRating, userLocationDto);
 
-        when(greenCityRemoteClient.getUserPicturePath(userId)).thenReturn("http://testpicture.com.ua");
+        when(greenCityRemoteClient.findGreenCityUserProfileByUserId(userId)).thenReturn(greenCityUserProfile);
 
         UserProfileDtoResponse expectedResult = UserProfileDtoResponse.builder()
-            .profilePicturePath("http://testpicture.com.ua")
+            .profilePicturePath(profilePicturePath)
             .name(user.getName())
             .userCredo(userCredo)
             .socialNetworks(expectedSocialNetworks)
@@ -70,12 +74,6 @@ class UserProfileDtoResponseMapperTest {
             .thenReturn(socialNetworkResponseDTO);
         when(modelMapper.map(any(UserNotificationPreference.class), eq(UserNotificationPreferenceDto.class)))
             .thenReturn(userNotificationPreferenceDto);
-        when(greenCityRemoteClient.findUserCredoByUserId(userId))
-            .thenReturn(userCredo);
-        when(greenCityRemoteClient.findUserRatingByUserId(userId))
-            .thenReturn(userRating);
-        when(greenCityRemoteClient.findUserLocationByUserId(userId))
-            .thenReturn(Optional.of(userLocationDto));
 
         UserProfileDtoResponse actualResult = userProfileDtoResponseMapper.convert(user);
 


### PR DESCRIPTION
Replace multiple calls and calls in loop to remote client with single call. In UserServiceImpl.saveUserProfile method, there are still multiple calls left but they are all non-blocking. Additionally, removed remote client methods that retrieved only a single field (e.g. get user's profile picture, get user's credo) and replaced them with a call to a more general getter method that retrieves GreenCityUserProfileDtoResponse containing all of the needed fields