### PR TITLE
Part of task #8321 - Added exception handling for WebClient for 4xx and 5xx errors.

### DIFF
--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -1,12 +1,14 @@
 package greencity.exception.handler;
 
 import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
 import greencity.exception.exceptions.BadRefreshTokenException;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.BadSocialNetworkLinksException;
 import greencity.exception.exceptions.BadUpdateRequestException;
 import greencity.exception.exceptions.BadUserStatusException;
 import greencity.exception.exceptions.EmailNotVerified;
+import greencity.exception.exceptions.GreenCityServiceException;
 import greencity.exception.exceptions.InvalidURLException;
 import greencity.exception.exceptions.LanguageNotSupportedException;
 import greencity.exception.exceptions.LanguageNotFoundException;
@@ -44,6 +46,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
@@ -138,8 +142,29 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     public final ResponseEntity<Object> handleNotFoundException(NotFoundException ex,
         WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        log.trace(ex.getMessage(), ex);
+        log.error(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+    /**
+     * Method interceptor for server errors-related exceptions which can be thrown by WebClient
+     * during making and receiving requests to the GreenCity app such as
+     * {@link GreenCityServiceException}, {@link WebClientRequestException},
+     * {@link WebClientResponseException}.
+     *
+     * @param request Contains details about the occurred exception.
+     * @return ResponseEntity which contains the HTTP status and body with the
+     *         message of the exception.
+     */
+    @ExceptionHandler({GreenCityServiceException.class, WebClientRequestException.class, WebClientResponseException.class})
+    public final ResponseEntity<Object> handleGreenCityServiceException(Exception ex, WebRequest request) {
+        if (ex instanceof WebClientRequestException) {
+            Map<String, String > errorBody = Map.of(AppConstant.MESSAGE, ErrorMessage.GREENCITY_APP_UNAVAILABLE);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorBody);
+        }
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        log.error(exceptionResponse.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exceptionResponse);
     }
 
     /**

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -147,19 +147,20 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
-     * Method interceptor for server errors-related exceptions which can be thrown by WebClient
-     * during making and receiving requests to the GreenCity app such as
-     * {@link GreenCityServiceException}, {@link WebClientRequestException},
+     * Method interceptor for server errors-related exceptions which can be thrown
+     * by WebClient during making and receiving requests to the GreenCity app such
+     * as {@link GreenCityServiceException}, {@link WebClientRequestException},
      * {@link WebClientResponseException}.
      *
      * @param request Contains details about the occurred exception.
      * @return ResponseEntity which contains the HTTP status and body with the
      *         message of the exception.
      */
-    @ExceptionHandler({GreenCityServiceException.class, WebClientRequestException.class, WebClientResponseException.class})
+    @ExceptionHandler({GreenCityServiceException.class, WebClientRequestException.class,
+        WebClientResponseException.class})
     public final ResponseEntity<Object> handleGreenCityServiceException(Exception ex, WebRequest request) {
         if (ex instanceof WebClientRequestException) {
-            Map<String, String > errorBody = Map.of(AppConstant.MESSAGE, ErrorMessage.GREENCITY_APP_UNAVAILABLE);
+            Map<String, String> errorBody = Map.of(AppConstant.MESSAGE, ErrorMessage.GREENCITY_APP_UNAVAILABLE);
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorBody);
         }
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));

--- a/service-api/src/main/java/greencity/client/config/GreenCityRemoteWebClientConfig.java
+++ b/service-api/src/main/java/greencity/client/config/GreenCityRemoteWebClientConfig.java
@@ -1,7 +1,13 @@
 package greencity.client.config;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
 import greencity.enums.Role;
+import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.GreenCityServiceException;
+import greencity.exception.exceptions.NotFoundException;
 import greencity.security.jwt.JwtTool;
 import io.netty.channel.ChannelOption;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -41,6 +48,7 @@ public class GreenCityRemoteWebClientConfig {
         return builder.baseUrl(greenCityBaseUrl)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .filter(authorizationHeaderFilter())
+            .filter(handlingWebClientExceptions())
             .clientConnector(
                 new ReactorClientHttpConnector(
                     HttpClient.create()
@@ -62,5 +70,26 @@ public class GreenCityRemoteWebClientConfig {
 
             return Mono.just(authorizedRequest);
         });
+    }
+
+    private ExchangeFilterFunction handlingWebClientExceptions() {
+        return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> clientResponse.bodyToMono(String.class)
+            .handle((errorBody, sink) -> {
+                switch (clientResponse.statusCode()) {
+                    case HttpStatus.NOT_FOUND -> sink.error(new NotFoundException(populateErrorMessage(errorBody)));
+                    case HttpStatus.BAD_REQUEST -> sink.error(new BadRequestException(populateErrorMessage(errorBody)));
+                    case HttpStatus.INTERNAL_SERVER_ERROR -> sink.error(new GreenCityServiceException(populateErrorMessage(errorBody)));
+                    default -> sink.error(new IllegalStateException(ErrorMessage.INTERNAL_SERVER_ERROR + errorBody));
+                }
+            }));
+    }
+
+    private String populateErrorMessage(String errorBody) {
+        record JsonMessage(String timestamp, short status, String error, String trace, String message, String path) {}
+        try {
+            return new ObjectMapper().readValue(errorBody, JsonMessage.class).message();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/service-api/src/main/java/greencity/client/config/GreenCityRemoteWebClientConfig.java
+++ b/service-api/src/main/java/greencity/client/config/GreenCityRemoteWebClientConfig.java
@@ -78,14 +78,17 @@ public class GreenCityRemoteWebClientConfig {
                 switch (clientResponse.statusCode()) {
                     case HttpStatus.NOT_FOUND -> sink.error(new NotFoundException(populateErrorMessage(errorBody)));
                     case HttpStatus.BAD_REQUEST -> sink.error(new BadRequestException(populateErrorMessage(errorBody)));
-                    case HttpStatus.INTERNAL_SERVER_ERROR -> sink.error(new GreenCityServiceException(populateErrorMessage(errorBody)));
+                    case HttpStatus.INTERNAL_SERVER_ERROR -> sink
+                        .error(new GreenCityServiceException(populateErrorMessage(errorBody)));
                     default -> sink.error(new IllegalStateException(ErrorMessage.INTERNAL_SERVER_ERROR + errorBody));
                 }
             }));
     }
 
     private String populateErrorMessage(String errorBody) {
-        record JsonMessage(String timestamp, short status, String error, String trace, String message, String path) {}
+        record JsonMessage(String timestamp, short status, String error, String trace, String message, String path) {
+        }
+
         try {
             return new ObjectMapper().readValue(errorBody, JsonMessage.class).message();
         } catch (JsonProcessingException e) {

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -34,4 +34,5 @@ public class AppConstant {
     public static final String USER_STATUS = "user_status";
     public static final String DEFAULT_SOCIAL_NETWORK_IMAGE_HOST_PATH = "img/default_social_network_icon.png";
     public static final String EMPTY_STRING = "";
+    public static final String MESSAGE = "message";
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -66,5 +66,5 @@ public class ErrorMessage {
         "Git repository not initialized. Commit info is unavailable.";
     public static final String FAILED_TO_FETCH_COMMIT_INFO = "Failed to fetch commit info due to I/O error: ";
     public static final String INTERNAL_SERVER_ERROR = "Internal server error: ";
-    public static final String GREENCITY_APP_UNAVAILABLE= "The GreenCity service is unavailable";
+    public static final String GREENCITY_APP_UNAVAILABLE = "The GreenCity service is unavailable";
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -65,4 +65,6 @@ public class ErrorMessage {
     public static final String GIT_REPOSITORY_NOT_INITIALIZED =
         "Git repository not initialized. Commit info is unavailable.";
     public static final String FAILED_TO_FETCH_COMMIT_INFO = "Failed to fetch commit info due to I/O error: ";
+    public static final String INTERNAL_SERVER_ERROR = "Internal server error: ";
+    public static final String GREENCITY_APP_UNAVAILABLE= "The GreenCity service is unavailable";
 }

--- a/service-api/src/main/java/greencity/exception/exceptions/GreenCityServiceException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/GreenCityServiceException.java
@@ -1,0 +1,10 @@
+package greencity.exception.exceptions;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Exception that can be thrown when call GreenCity app using WebClient but GreenCity app returns a 500 error.
+ */
+@StandardException
+public class GreenCityServiceException extends RuntimeException {
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/GreenCityServiceException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/GreenCityServiceException.java
@@ -3,7 +3,8 @@ package greencity.exception.exceptions;
 import lombok.experimental.StandardException;
 
 /**
- * Exception that can be thrown when call GreenCity app using WebClient but GreenCity app returns a 500 error.
+ * Exception that can be thrown when call GreenCity app using WebClient but
+ * GreenCity app returns a 500 error.
  */
 @StandardException
 public class GreenCityServiceException extends RuntimeException {


### PR DESCRIPTION
# GreenCity User PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8321">#8321</a>

## Changed
- Added _handlingWebClientExceptions_ and _populateErrorMessage_ into `GreenCityRemoteWebClientConfig` for handling `WebClient` errors;
- Added exception `GreenCityServiceException`;
- Added method _handleGreenCityServiceException_ in the `CustomExceptionHandler` for handling such errors as `GreenCityServiceException`, `WebClientRequestException`, `WebClientResponseException`;
- Added _MESSAGE_ constant into `AppConstant` class:
- Added _GREENCITY_APP_UNAVAILABLE_ constant into `ErrorMessage` class;

## Summary Of Changes 🔥
Added functionality handling 4xx and 5xx errors during sending and receiving requests to the **GreenCity** app using `WebClient`.