### PR TITLE
Bugfix #8737 Fixed email verification

### DIFF
--- a/service-api/src/main/java/greencity/client/RestClient.java
+++ b/service-api/src/main/java/greencity/client/RestClient.java
@@ -6,6 +6,8 @@ import greencity.dto.socialnetwork.SocialNetworkImageVO;
 import greencity.dto.todolist.CustomToDoListItemResponseDto;
 import greencity.dto.ubs.UbsProfileCreationDto;
 import greencity.dto.user.UserVO;
+import greencity.enums.Role;
+import greencity.security.jwt.JwtTool;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ import static greencity.constant.AppConstant.FILES;
 public class RestClient {
     private final RestTemplate restTemplate;
     private final HttpServletRequest httpServletRequest;
+    private final JwtTool jwtTool;
     @Value("${greencity.server.address}")
     private String greenCityServerAddress;
     @Value("${greencitychat.server.address}")
@@ -181,9 +184,15 @@ public class RestClient {
      * @author Maksym Golik
      */
     public Long createUbsProfile(UbsProfileCreationDto ubsProfile) throws RestClientException {
+        String accessToken = "Bearer " + jwtTool.createAccessToken("service@greencity.ua",
+            Role.ROLE_ADMIN);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, accessToken);
+        HttpEntity<UbsProfileCreationDto> entity = new HttpEntity<>(ubsProfile, headers);
+
         return restTemplate
             .postForEntity(greenCityUbsServerAddress + RestTemplateLinks.UBS_USER_PROFILE + "/user/create",
-                ubsProfile, Long.class)
+                entity, Long.class)
             .getBody();
     }
 

--- a/service-api/src/test/java/greencity/client/RestClientTest.java
+++ b/service-api/src/test/java/greencity/client/RestClientTest.java
@@ -7,6 +7,7 @@ import greencity.dto.friends.FriendsChatDto;
 import greencity.dto.todolist.CustomToDoListItemResponseDto;
 import greencity.dto.socialnetwork.SocialNetworkImageVO;
 import greencity.dto.ubs.UbsProfileCreationDto;
+import greencity.security.jwt.JwtTool;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,6 +42,8 @@ class RestClientTest {
     private RestTemplate restTemplate;
     @Mock
     private HttpServletRequest httpServletRequest;
+    @Mock
+    private JwtTool jwtTool;
     @Value("${greencity.server.address}")
     private String greenCityServerAddress;
     @Value("${greencitychat.server.address}")
@@ -202,13 +205,17 @@ class RestClientTest {
                 .email("ubsemail@mail.com")
                 .name("UBS")
                 .build();
+        when(jwtTool.createAccessToken(any(), any())).thenReturn("token");
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, "Bearer token");
+        HttpEntity<UbsProfileCreationDto> entity = new HttpEntity<>(ubsProfileCreationDto, headers);
         ResponseEntity<Long> responseEntity = ResponseEntity.status(HttpStatus.CREATED).body(1L);
         when(restTemplate.postForEntity(greenCityUbsServerAddress + RestTemplateLinks.UBS_USER_PROFILE + "/user/create",
-            ubsProfileCreationDto, Long.class)).thenReturn(responseEntity);
+            entity, Long.class)).thenReturn(responseEntity);
         Long id = restClient.createUbsProfile(ubsProfileCreationDto);
         verify(restTemplate, times(1)).postForEntity(
             greenCityUbsServerAddress + RestTemplateLinks.UBS_USER_PROFILE + "/user/create",
-            ubsProfileCreationDto, Long.class);
+            entity, Long.class);
         assertEquals(1L, id);
     }
 


### PR DESCRIPTION
# GreenCityUser PR
[#8737](https://github.com/ita-social-projects/GreenCity/issues/8737)

## Summary Of Changes :fire:
Fixed email verification, user can create a new account as intended.

## Changed
* `RestClient` now uses the injected `JwtTool` to generate a bearer token for UBS requests.
* Modified `RestClientTest` to reflect changes in `RestClient`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security for creating UBS profiles by adding token-based authorization to requests.

* **Tests**
  * Updated tests to verify the inclusion of authorization headers when creating UBS profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->