### PR TITLE
Align email validation across all entities and dtos

### DIFF
--- a/core/src/main/java/greencity/constant/ValidationConstants.java
+++ b/core/src/main/java/greencity/constant/ValidationConstants.java
@@ -4,7 +4,15 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ValidationConstants {
-    public static final String EMAIL_REGEXP = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
+    public static final String EMAIL_REGEXP =
+        "^(?=.{3,72}$)"
+            + "([a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+"
+            + "(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+)*)"
+            + "@"
+            + "(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+"
+            + "[a-zA-Z]{2,63}|"
+            + "\\[(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)"
+            + "(?:\\.(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)){3}\\])$";
     public static final String INVALID_EMAIL = "{greenCity.validation.invalid.email}";
 
     public static final String USER_CREATED = "{greenCity.validation.user.created}";

--- a/dao/src/main/java/greencity/entity/User.java
+++ b/dao/src/main/java/greencity/entity/User.java
@@ -73,7 +73,7 @@ public class User {
     @Column(nullable = false, length = 30)
     private String name;
 
-    @Column(unique = true, nullable = false, length = 50)
+    @Column(unique = true, nullable = false, length = 72)
     private String email;
 
     @Enumerated(value = EnumType.STRING)

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -16,13 +16,14 @@ public class AppConstant {
     public static final String ROLE = "role";
     public static final String AUTHORIZATION = "Authorization";
     public static final String VALIDATION_EMAIL_REGEXP =
-        """
-            (?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\
-            \\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*")@(?:(?:[a-zA-Z0-9](?:\
-            [a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|\
-            [01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\\x01-\\x08\
-            \\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])\
-            """;
+        "^(?=.{3,72}$)"
+            + "([a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+"
+            + "(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+)*)"
+            + "@"
+            + "(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+"
+            + "[a-zA-Z]{2,63}|"
+            + "\\[(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)"
+            + "(?:\\.(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)){3}\\])$";
     public static final Double DEFAULT_RATING = 0.0;
     public static final String USERNAME = "name";
     public static final String FACEBOOK_OBJECT_ID = "me";

--- a/service-api/src/main/java/greencity/constant/ValidationConstants.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstants.java
@@ -4,7 +4,15 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ValidationConstants {
-    public static final String EMAIL_REGEXP = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
+    public static final String EMAIL_REGEXP =
+        "^(?=.{3,72}$)"
+            + "([a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+"
+            + "(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_{|}~-]+)*)"
+            + "@"
+            + "(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+"
+            + "[a-zA-Z]{2,63}|"
+            + "\\[(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)"
+            + "(?:\\.(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)){3}\\])$";
     public static final String INVALID_EMAIL = "{greenCity.validation.invalid.email}";
     public static final String USERNAME_MESSAGE = """
         Name must start with a letter, \


### PR DESCRIPTION
This pull request updates the email validation logic across multiple files to enhance its accuracy and flexibility. It also increases the maximum allowed length for email addresses in the `User` entity. Below is a summary of the key changes:

### Email Validation Enhancements:
* [`core/src/main/java/greencity/constant/ValidationConstants.java`](diffhunk://#diff-999e4df14c02c3cb66c1ebedcd6d227885df2649c1f66855e571db4f9a45ce22L7-R15): Updated the `EMAIL_REGEXP` pattern to enforce stricter validation, including support for longer email addresses (up to 72 characters) and more robust domain validation.
* [`service-api/src/main/java/greencity/constant/ValidationConstants.java`](diffhunk://#diff-5274e10433b46e50e9bf0f756d080274e8691efee7db86aae9c650f2c2de8d13L7-R15): Applied the same enhanced `EMAIL_REGEXP` pattern for consistency across the service API layer.
* [`service-api/src/main/java/greencity/constant/AppConstant.java`](diffhunk://#diff-50c9cbbfb4ab933ca51a784146c3b14eadb1d0608a4a3c615a68de1a23e690bbL19-R26): Replaced the previous `VALIDATION_EMAIL_REGEXP` with the updated pattern to ensure uniform validation logic.

### Entity Updates:
* [`dao/src/main/java/greencity/entity/User.java`](diffhunk://#diff-6f8708925b981b4281a01e72019c48594706c08744df1533bffc7d8a2ea21201L76-R76): Increased the maximum length of the `email` column from 50 to 72 characters to align with the updated validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced email validation to support a wider range of valid email formats and longer email addresses (up to 72 characters).
* **Bug Fixes**
  * Improved accuracy of email address validation, reducing the chance of valid emails being incorrectly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->