### PR TITLE
Fix security config by moving enpoint /user/deleteProfilePicture from…

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -185,12 +185,12 @@ public class SecurityConfig {
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.PATCH,
                     "/user/to-do-list-items/{userToDoListItemId}",
-                    "/user/profilePicture",
-                    "/user/deleteProfilePicture")
+                    "/user/profilePicture")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.DELETE,
                     "/user/to-do-list-items/user-to-do-list-items",
                     "/user/to-do-list-items",
+                    "/user/deleteProfilePicture",
                     "/ownSecurity/user")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,


### PR DESCRIPTION
### 🔗 **Issue:** [#8889](https://github.com/ita-social-projects/GreenCity/issues/8889)

This pull request makes a minor update to the security configuration in `SecurityConfig.java`. The main change is that the `DELETE /user/deleteProfilePicture` endpoint now requires authorization, while the `PATCH /user/deleteProfilePicture` endpoint has been removed from the list of authorized endpoints.

Authorization rules update:

* Removed `PATCH /user/deleteProfilePicture` from the list of endpoints requiring authorization for roles `USER`, `ADMIN`, `UBS_EMPLOYEE`, `MODERATOR`, and `EMPLOYEE` in the PATCH method, and added `DELETE /user/deleteProfilePicture` to the list of endpoints requiring authorization for the same roles in the DELETE method. (`core/src/main/java/greencity/config/SecurityConfig.java`)… patch request matcher to delete where it should belong

✅ **This pull request closes** [#8889](https://github.com/ita-social-projects/GreenCity/issues/8889) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated access control for user profile picture management endpoints by changing the required HTTP method from PATCH to DELETE for deleting profile pictures.
  * Adjusted security roles required for accessing the updated endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->