### PR TITLE
#9004 - Provide an endpoint for user status check

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -247,7 +247,7 @@ public class SecurityConfig {
                     "/user/statuses-distribution",
                     "/user/roles-distribution",
                     "/user/findNotDeactivatedById",
-                    "user/checkActiveUserByUuid",
+                    "/user/checkActiveUserByUuid",
                     "/user/findNotDeactivatedByEmail")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.DELETE,

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -247,6 +247,7 @@ public class SecurityConfig {
                     "/user/statuses-distribution",
                     "/user/roles-distribution",
                     "/user/findNotDeactivatedById",
+                    "user/checkActiveUserByUuid",
                     "/user/findNotDeactivatedByEmail")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.DELETE,

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -932,6 +932,22 @@ public class UserController {
     }
 
     /**
+     * Check the existence of an active user by uuid.
+     *
+     * @param uuid user's uuid.
+     * @return {@link Boolean}.
+     */
+    @Operation(summary = "Check the existence of an active user by uuid")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+    })
+    @GetMapping("/checkActiveUserByUuid")
+    public ResponseEntity<Boolean> checkIfActiveUserExistsByUuId(@RequestParam String uuid) {
+        return ResponseEntity.ok().body(userService.checkIfActiveUserExistsByUuid(uuid));
+    }
+
+    /**
      * Method for mark user like DEACTIVATED .
      *
      * @param uuid - for found user.

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -927,6 +927,15 @@ class UserControllerTest {
     }
 
     @Test
+    void checkIfActiveUserExistsByUuidTest() throws Exception {
+        when(userService.checkIfActiveUserExistsByUuid(TestConst.UUID)).thenReturn(true);
+        mockMvc.perform(get(userLink + "/checkActiveUserByUuid")
+                .param("uuid", TestConst.UUID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(true));
+    }
+
+    @Test
     void editUserRatingTest() throws Exception {
         Principal principal = mock(Principal.class);
         when(principal.getName()).thenReturn("testmail@gmail.com");

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -930,9 +930,9 @@ class UserControllerTest {
     void checkIfActiveUserExistsByUuidTest() throws Exception {
         when(userService.checkIfActiveUserExistsByUuid(TestConst.UUID)).thenReturn(true);
         mockMvc.perform(get(userLink + "/checkActiveUserByUuid")
-                .param("uuid", TestConst.UUID))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").value(true));
+            .param("uuid", TestConst.UUID))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").value(true));
     }
 
     @Test

--- a/dao/src/main/java/greencity/repository/UserRepo.java
+++ b/dao/src/main/java/greencity/repository/UserRepo.java
@@ -389,6 +389,15 @@ public interface UserRepo extends JpaRepository<User, Long>, JpaSpecificationExe
     boolean existsNotDeactivatedByUuid(@Param("uuid") String uuid);
 
     /**
+     * Checks if there is an active user with the given uuid (userStatus == 2).
+     *
+     * @param uuid the UUID of the user
+     * @return true if such a user exists, false otherwise
+     */
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE u.uuid =:uuid AND u.userStatus = 2")
+    boolean existsActiveByUuid(@Param("uuid") String uuid);
+
+    /**
      * Finds a user by UUID if the user is not deactivated (userStatus ≠ 1).
      *
      * @param uuid the UUID of the user

--- a/service-api/src/main/java/greencity/service/UserService.java
+++ b/service-api/src/main/java/greencity/service/UserService.java
@@ -427,6 +427,13 @@ public interface UserService {
     Boolean checkIfUserExistsByUuid(String uuid);
 
     /**
+     * Method checks the existence of an active user by uuid.
+     * 
+     * @param uuid user's uuid.
+     */
+    boolean checkIfActiveUserExistsByUuid(String uuid);
+
+    /**
      * Updates last activity time for a given user by email.
      *
      * @param email                - {@link UserVO}'s email.

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -993,6 +993,14 @@ public class UserServiceImpl implements UserService {
      * {@inheritDoc}
      */
     @Override
+    public boolean checkIfActiveUserExistsByUuid(String uuid) {
+        return userRepo.existsActiveByUuid(uuid);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void updateUserLastActivityTimeByEmail(String email, LocalDateTime userLastActivityTime) {
         userRepo.updateUserLastActivityTimeByEmail(email, userLastActivityTime);
     }

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1268,6 +1268,20 @@ class UserServiceImplTest {
             Arguments.of("uuid", Optional.empty(), false));
     }
 
+    @ParameterizedTest
+    @MethodSource("provideUserUuidAndExistence")
+    void checkIfActiveUserExistsByUuidTest(String uuid, boolean existence) {
+        when (userRepo.existsActiveByUuid(uuid)).thenReturn(existence);
+        assertEquals(existence, userService.checkIfActiveUserExistsByUuid(uuid));
+    }
+
+    private static Stream<Arguments> provideUserUuidAndExistence(){
+        return Stream.of(
+                Arguments.of("activeUserUuid", true),
+                Arguments.of("inactiveUserUuid", false)
+        );
+    }
+
     @Test
     void editUserRatingTest() {
         UserAddRatingDto userRatingDto2 = UserAddRatingDto.builder()

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1271,15 +1271,14 @@ class UserServiceImplTest {
     @ParameterizedTest
     @MethodSource("provideUserUuidAndExistence")
     void checkIfActiveUserExistsByUuidTest(String uuid, boolean existence) {
-        when (userRepo.existsActiveByUuid(uuid)).thenReturn(existence);
+        when(userRepo.existsActiveByUuid(uuid)).thenReturn(existence);
         assertEquals(existence, userService.checkIfActiveUserExistsByUuid(uuid));
     }
 
-    private static Stream<Arguments> provideUserUuidAndExistence(){
+    private static Stream<Arguments> provideUserUuidAndExistence() {
         return Stream.of(
-                Arguments.of("activeUserUuid", true),
-                Arguments.of("inactiveUserUuid", false)
-        );
+            Arguments.of("activeUserUuid", true),
+            Arguments.of("inactiveUserUuid", false));
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUser PR
## Issue Link :clipboard:
[#9004](https://github.com/ita-social-projects/GreenCity/issues/9004)

## Summary Of Changes :fire:
* Implemented a mechanism for checking whether the user is active.
* Provided an endpoint `/user/checkActiveUserByUuid` for inter-service communication.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoint to check if a user is active by UUID.
  - Expanded admin tools: activate/deactivate users, manage authorities/positions, update ratings.
  - Added analytics and trends: distributions (roles, statuses, email prefs), active user count, registration months, user cities.
  - Improved search/filtering: find users by name, email notification; schedule deletion of deactivated users.
- Security
  - Updated admin access rules to include the new endpoint.
- Tests
  - Added coverage for active-user existence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->