### PR TITLE
Added liquibase migration for inserting into own_security

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -31,5 +31,5 @@
     <include file="db/changelog/logs/ch-create-retryable-task-table-Pohranychnyi.xml"/>
     <include file="db/changelog/logs/ch-insert-into-employee-positions-mapping-Lys.xml"/>
     <include file="db/changelog/logs/ch-add-authority-category-table-Popovych.xml"/>
-
+    <include file="db/changelog/logs/ch-insert-passwords-into-own-security-Lys.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-passwords-into-own-security-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-passwords-into-own-security-Lys.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="ch-insert-passwords-into-own-security-Lys" author="BohdanLys">
+        <insert tableName="own_security">
+            <column name="password" value="$2a$10$OjKiBFH2yUgvCpJnoGE4fe6dhJSh6Q7cdkm75cg1I/Z25SE7sJCUi"/>
+            <column name="user_id" value="2"/>
+        </insert>
+        <insert tableName="own_security">
+            <column name="password" value="$2a$10$OjKiBFH2yUgvCpJnoGE4fe6dhJSh6Q7cdkm75cg1I/Z25SE7sJCUi"/>
+            <column name="user_id" value="3"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/service/src/main/java/greencity/config/RetryableTaskScheduler.java
+++ b/service/src/main/java/greencity/config/RetryableTaskScheduler.java
@@ -24,7 +24,7 @@ public class RetryableTaskScheduler {
     private final RetryableTaskProcessorRegistry registry;
     private final ModelMapper modelMapper;
 
-    @Scheduled(fixedRate = 30000)
+    @Scheduled(fixedRate = 21600000)
     public void executePendingTasks() {
         List<RetryableTask> tasks = retryableTaskService.getRetryableTaskForProcessing();
         for (RetryableTask task : tasks) {
@@ -38,6 +38,7 @@ public class RetryableTaskScheduler {
                 repository.save(task);
             } catch (TaskProcessingException e) {
                 log.warn("TaskProcessingException for task {}: {}", task.getId(), e.getMessage());
+
             } catch (Exception e) {
                 log.error("Unexpected error for task {}: {}", task.getId(), e.getMessage(), e);
             }

--- a/service/src/main/java/greencity/config/RetryableTaskScheduler.java
+++ b/service/src/main/java/greencity/config/RetryableTaskScheduler.java
@@ -38,7 +38,6 @@ public class RetryableTaskScheduler {
                 repository.save(task);
             } catch (TaskProcessingException e) {
                 log.warn("TaskProcessingException for task {}: {}", task.getId(), e.getMessage());
-
             } catch (Exception e) {
                 log.error("Unexpected error for task {}: {}", task.getId(), e.getMessage(), e);
             }

--- a/service/src/main/java/greencity/service/RetryableTaskServiceImpl.java
+++ b/service/src/main/java/greencity/service/RetryableTaskServiceImpl.java
@@ -24,7 +24,7 @@ public class RetryableTaskServiceImpl implements RetryableTaskService {
     private final RetryableTaskRepository retryableTaskRepository;
     private final ObjectMapper objectMapper;
     private static final Integer LIMIT = 100;
-    private static final Integer TIMEOUTINSECONDS = 60;
+    private static final Integer TIMEOUTINSECONDS = 18000;
 
     @Transactional
     public <T> void saveRetryableTask(T payloadObject, RetryableTaskType type) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a database migration that inserts initial security records for specific user accounts and adjusted migration ordering so it runs during deployment.
- Behavior
  - Extended background retry scheduling: the periodic task runner now runs much less frequently and retry delays increased from seconds to multi-hour intervals, reducing immediate retries and spreading processing over longer windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->