### PR TITLE
Feature: 1806 send feedback to customer email

### DIFF
--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -132,6 +132,13 @@ public class EmailController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * Send an email with user feedback received from the Telegram bot.
+     *
+     * @param dto {@link UserTelegramFeedbackDto} - object containing the feedback
+     *            details: chat ID, username, rating, optional comment and email
+     *            subject.
+     */
     @Operation(summary = "Send telegram user feedback to customer email")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -2,6 +2,7 @@ package greencity.controller;
 
 import greencity.constant.HttpStatuses;
 import greencity.dto.econews.InterestingEcoNewsDto;
+import greencity.dto.user.UserTelegramFeedbackDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.message.*;
 import greencity.service.EmailService;
@@ -128,6 +129,18 @@ public class EmailController {
     @PostMapping("/sendPlaceStatusChange")
     public ResponseEntity<Object> sendPlaceStatusChange(@RequestBody PlaceStatusChangeDto dto) {
         emailService.sendPlaceStatusChangeNotification(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Send telegram user feedback to customer email")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/telegram-feedback")
+    public ResponseEntity<Void> sendTelegramFeedback(@RequestBody UserTelegramFeedbackDto dto) {
+        emailService.sendTelegramFeedbackEmail(dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -9,6 +9,7 @@ import greencity.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -146,7 +147,7 @@ public class EmailController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @PostMapping("/telegram-feedback")
-    public ResponseEntity<Void> sendTelegramFeedback(@RequestBody UserTelegramFeedbackDto dto) {
+    public ResponseEntity<Void> sendTelegramFeedback(@RequestBody @Valid UserTelegramFeedbackDto dto) {
         emailService.sendTelegramFeedbackEmail(dto);
         return ResponseEntity.ok().build();
     }

--- a/core/src/main/resources/templates/email/telegram-feedback.html
+++ b/core/src/main/resources/templates/email/telegram-feedback.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h2>New Feedback from Telegram Bot</h2>
+
+<p><strong>Chat ID:</strong> <span th:text="${chatId}"></span></p>
+<p><strong>User Name:</strong> <span th:text="${name}"></span></p>
+<p><strong>Rating:</strong> <span th:text="${rating}"></span></p>
+<p><strong>Comment:</strong></p>
+<p th:text="${comment}"></p>
+</body>
+</html>

--- a/core/src/main/resources/templates/email/telegram-feedback.html
+++ b/core/src/main/resources/templates/email/telegram-feedback.html
@@ -1,16 +1,66 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="uk">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Новий відгук</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #F5F6F6;
+            font-family: Lato, Arial, sans-serif;
+        }
+
+        .email-container {
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #FFFFFF;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+            overflow: hidden;
+        }
+
+        .header {
+            text-align: center;
+            background-color: #87BC1E;
+            color: white;
+            padding: 20px;
+        }
+
+        .header h2 {
+            margin: 0;
+            font-size: 20px;
+        }
+
+        .content {
+            padding: 26px;
+            font-size: 16px;
+            line-height: 1.5;
+            color: #333333;
+        }
+
+        .content p {
+            margin: 10px 0;
+        }
+
+        .label {
+            font-weight: bold;
+            color: #555555;
+        }
+    </style>
 </head>
 <body>
-<h2>New Feedback from Telegram Bot</h2>
-
-<p><strong>Chat ID:</strong> <span th:text="${chatId}"></span></p>
-<p><strong>User Name:</strong> <span th:text="${name}"></span></p>
-<p><strong>Rating:</strong> <span th:text="${rating}"></span></p>
-<p><strong>Comment:</strong></p>
-<p th:text="${comment}"></p>
+<div class="email-container">
+    <div class="header">
+        <h2>Новий відгук від користувача Telegram-бота</h2>
+    </div>
+    <div class="content">
+        <p><span class="label">ID чату:</span> <span th:text="${chatId}"></span></p>
+        <p><span class="label">Ім'я користувача:</span> <span th:text="${name}"></span></p>
+        <p><span class="label">Рейтинг:</span> <span th:text="${rating}"></span></p>
+        <p class="label">Коментар:</p>
+        <p th:text="${comment}"></p>
+    </div>
+</div>
 </body>
 </html>

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -226,7 +226,7 @@ class EmailControllerTest {
     }
 
     @Test
-    public void testSendTelegramFeedback_Success() throws Exception {
+    void testSendTelegramFeedback_Success() throws Exception {
         UserTelegramFeedbackDto dto = new UserTelegramFeedbackDto();
         dto.setChatId("12345");
         dto.setName("John Doe");

--- a/core/src/test/java/greencity/controller/EmailControllerTest.java
+++ b/core/src/test/java/greencity/controller/EmailControllerTest.java
@@ -3,6 +3,7 @@ package greencity.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import greencity.dto.econews.InterestingEcoNewsDto;
+import greencity.dto.user.UserTelegramFeedbackDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.enums.PlaceStatus;
 import greencity.message.PlaceStatusChangeDto;
@@ -222,5 +223,21 @@ class EmailControllerTest {
             .andExpect(status().isOk());
 
         verify(emailService, times(1)).sendGreenOfficeRequestEmailToManager(message);
+    }
+
+    @Test
+    public void testSendTelegramFeedback_Success() throws Exception {
+        UserTelegramFeedbackDto dto = new UserTelegramFeedbackDto();
+        dto.setChatId("12345");
+        dto.setName("John Doe");
+        dto.setRating(5);
+        dto.setComment("Great service!");
+        ObjectMapper objectMapper = new ObjectMapper();
+        mockMvc.perform(MockMvcRequestBuilders.post(LINK + "/telegram-feedback")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(dto)))
+            .andExpect(status().isOk());
+
+        verify(emailService, times(1)).sendTelegramFeedbackEmail(dto);
     }
 }

--- a/service-api/src/main/java/greencity/constant/EmailConstants.java
+++ b/service-api/src/main/java/greencity/constant/EmailConstants.java
@@ -43,6 +43,9 @@ public class EmailConstants {
     public static final String NOTIFICATIONS_LINK = "notificationsLink";
     public static final String PLACE_NAME = "placeName";
     public static final String PLACE_STATUS = "placeStatus";
+    public static final String CHAT_ID = "chatId";
+    public static final String RATING = "rating";
+    public static final String COMMENT = "comment";
     // templates
     public static final String VERIFY_EMAIL_PAGE = "verify-email-page";
     public static final String RESTORE_EMAIL_PAGE = "restore-email-page";
@@ -58,4 +61,5 @@ public class EmailConstants {
     public static final String BLOCKED_USER_PAGE = "blocked-user-page";
     public static final String PLACE_STATUS_CHANGE_PAGE = "place-status-change";
     public static final String GREEN_OFFICE_REQUEST_PAGE = "green-office-request";
+    public static final String TELEGRAM_FEEDBACK = "telegram-feedback";
 }

--- a/service-api/src/main/java/greencity/dto/user/UserTelegramFeedbackDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserTelegramFeedbackDto.java
@@ -1,5 +1,10 @@
 package greencity.dto.user;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,9 +15,21 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 public class UserTelegramFeedbackDto {
+    @NotBlank
+    @Size(max = 64)
     private String chatId;
+
+    @Size(max = 255)
     private String name;
+
+    @Min(1)
+    @Max(5)
     private int rating;
+
+    @Size(max = 2000)
     private String comment;
+
+    @Size(max = 255)
+    @Pattern(regexp = "^[^\r\n]*$", message = "Subject must not contain CR or LF characters")
     private String subject;
 }

--- a/service-api/src/main/java/greencity/dto/user/UserTelegramFeedbackDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserTelegramFeedbackDto.java
@@ -1,0 +1,18 @@
+package greencity.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class UserTelegramFeedbackDto {
+    private String chatId;
+    private String name;
+    private int rating;
+    private String comment;
+    private String subject;
+}

--- a/service-api/src/main/java/greencity/service/EmailService.java
+++ b/service-api/src/main/java/greencity/service/EmailService.java
@@ -158,5 +158,13 @@ public interface EmailService {
      */
     void sendGreenOfficeRequestEmailToManager(ScheduledEmailMessage message);
 
+    /**
+     * Sends an email notification containing user feedback received from the
+     * Telegram bot.
+     *
+     * @param dto {@link UserTelegramFeedbackDto} the data transfer object
+     *            containing details such as chat ID, username, rating, comment and
+     *            email subject.
+     */
     void sendTelegramFeedbackEmail(UserTelegramFeedbackDto dto);
 }

--- a/service-api/src/main/java/greencity/service/EmailService.java
+++ b/service-api/src/main/java/greencity/service/EmailService.java
@@ -3,6 +3,7 @@ package greencity.service;
 import greencity.dto.econews.InterestingEcoNewsDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserTelegramFeedbackDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.message.PlaceStatusChangeDto;
 import greencity.message.ScheduledEmailMessage;
@@ -156,4 +157,6 @@ public interface EmailService {
      * @param message {@link ScheduledEmailMessage}.
      */
     void sendGreenOfficeRequestEmailToManager(ScheduledEmailMessage message);
+
+    void sendTelegramFeedbackEmail(UserTelegramFeedbackDto dto);
 }

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -7,6 +7,7 @@ import greencity.dto.econews.InterestingEcoNewsDto;
 import greencity.dto.user.SubscriberDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserTelegramFeedbackDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.entity.User;
 import greencity.exception.exceptions.NotFoundException;
@@ -377,6 +378,18 @@ public class EmailServiceImpl implements EmailService {
 
         String template = createEmailTemplate(model, EmailConstants.GREEN_OFFICE_REQUEST_PAGE);
         sendEmail(greenOfficeEmailAddress, message.getSubject(), template);
+    }
+
+    @Override
+    public void sendTelegramFeedbackEmail(UserTelegramFeedbackDto dto) {
+        Map<String, Object> model = new HashMap<>();
+        model.put(EmailConstants.CHAT_ID, dto.getChatId());
+        model.put(EmailConstants.USER_NAME, dto.getName());
+        model.put(EmailConstants.RATING, dto.getRating());
+        model.put(EmailConstants.COMMENT, dto.getComment());
+
+        String template = createEmailTemplate(model, EmailConstants.TELEGRAM_FEEDBACK);
+        sendEmail(greenOfficeEmailAddress, dto.getSubject(), template);
     }
 
     private String getClientLinkByIsUbs(boolean isUbs) {

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -24,6 +24,7 @@ import greencity.dto.place.PlaceNotificationDto;
 import greencity.dto.user.SubscriberDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserTelegramFeedbackDto;
 import greencity.dto.violation.UserViolationMailDto;
 import greencity.entity.Language;
 import greencity.entity.User;
@@ -413,6 +414,19 @@ class EmailServiceImplTest {
             .build();
 
         service.sendGreenOfficeRequestEmailToManager(message);
+        verify(javaMailSender).createMimeMessage();
+    }
+
+    @Test
+    void testSendTelegramFeedbackEmail_Success() {
+        UserTelegramFeedbackDto feedbackDto = new UserTelegramFeedbackDto();
+        feedbackDto.setChatId("12345");
+        feedbackDto.setName("John Doe");
+        feedbackDto.setRating(5);
+        feedbackDto.setComment("Great service!");
+        feedbackDto.setSubject("Feedback Subject");
+        service.sendTelegramFeedbackEmail(feedbackDto);
+
         verify(javaMailSender).createMimeMessage();
     }
 }


### PR DESCRIPTION
# GreenCityUser PR
## Issue Link :clipboard:
[#1806](https://github.com/ita-social-projects/GreenCityUBS/issues/1806)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public API endpoint to submit Telegram bot feedback (validated input; returns 200 OK; documents 400/404).
  - Sends a localized (Ukrainian) styled email notification for each feedback showing chat ID, username, rating, comment, and subject.

- Tests
  - Added controller and service tests covering Telegram feedback submission and email-sending flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->