### PR TITLE
Fix deleteProfilePicture endpoint by using correct HTTP method DELETE…

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -80,6 +80,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -354,7 +355,7 @@ public class UserController {
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })
-    @PatchMapping(path = "/deleteProfilePicture")
+    @DeleteMapping(path = "/deleteProfilePicture")
     public ResponseEntity<HttpStatus> deleteUserProfilePicture(Principal principal) {
         userService.deleteUserProfilePicture(principal.getName());
         return ResponseEntity.ok().build();

--- a/core/src/test/java/greencity/controller/UserControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserControllerTest.java
@@ -89,6 +89,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -370,7 +371,7 @@ class UserControllerTest {
     void deleteUserProfilePictureTest() throws Exception {
         Principal principal = mock(Principal.class);
         when(principal.getName()).thenReturn("test@email.com");
-        mockMvc.perform(patch(userLink + "/deleteProfilePicture")
+        mockMvc.perform(delete(userLink + "/deleteProfilePicture")
             .principal(principal))
             .andExpect(status().isOk());
 


### PR DESCRIPTION
This pull request updates the API endpoint for deleting a user's profile picture to better follow RESTful conventions by switching from a `PATCH` to a `DELETE` HTTP method. It also updates the corresponding test to use the correct HTTP method.

API improvements:

* Changed the endpoint for deleting a user's profile picture in `UserController` from `@PatchMapping` to `@DeleteMapping`, ensuring the API uses the appropriate HTTP verb for resource deletion.
* Imported `DeleteMapping` in `UserController.java` to support the new HTTP method.

Test updates:

* Updated the test in `UserControllerTest` to use `MockMvcRequestBuilders.delete` instead of `patch` when testing the profile picture deletion endpoint. [[1]](diffhunk://#diff-b22949cd593261e493563a2c937fa933ff9d87bd5ed632c275428489fe5187d3L373-R374) [[2]](diffhunk://#diff-b22949cd593261e493563a2c937fa933ff9d87bd5ed632c275428489fe5187d3R92)… instead of PATCH