### PR TITLE
Added user access on check active user by uuid endpoint

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -152,6 +152,7 @@ public class SecurityConfig {
                     "/user/findUserByName/**",
                     "/user/findByUuId",
                     "/user/findUuidByEmail",
+                    "/user/checkActiveUserByUuid",
                     "/user/lang",
                     "/user/createUbsRecord",
                     "/user/{userId}/sixUserFriends/",
@@ -244,7 +245,6 @@ public class SecurityConfig {
                     "/user/statuses-distribution",
                     "/user/roles-distribution",
                     "/user/findNotDeactivatedById",
-                    "/user/checkActiveUserByUuid",
                     "/user/findNotDeactivatedByEmail")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.DELETE,


### PR DESCRIPTION
Added access for users on checkActiveUserByUuid endpoint, so ubs can succesfully create notifications and therefore orders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Activation status check is now publicly accessible. You can verify whether a user account is active without signing in or having admin privileges. Behavior of all other endpoints remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->