### PR TITLE
Task #9097 added env TG_BOT_FEEDBACKS_EMAIL_ADDRESS

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -28,6 +28,7 @@ address=http://localhost:8080
 client.address=http://localhost:4200
 sender.email.address=${EMAIL_ADDRESS}
 greenoffice.email.address=${GREEN_OFFICE_EMAIL_ADDRESS}
+tgbotfeedbacks.email.address=${TG_BOT_FEEDBACKS_EMAIL_ADDRESS}
 google.clientId=${GOOGLE_CLIENT_ID}
 google.clientId.manager=${GOOGLE_CLIENT_ID_MANAGER}
 # Token expiration time

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -28,6 +28,7 @@ address=http://core:8080
 client.address=http://localhost:4200
 sender.email.address=${EMAIL_ADDRESS}
 greenoffice.email.address=${GREEN_OFFICE_EMAIL_ADDRESS}
+tgbotfeedbacks.email.address=${TG_BOT_FEEDBACKS_EMAIL_ADDRESS}
 google.clientId=${GOOGLE_CLIENT_ID}
 google.clientId.manager=${GOOGLE_CLIENT_ID_MANAGER}
 # Token expiration time

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -29,6 +29,7 @@ address=${BACKEND_ADDRESS}
 client.address=${CLIENT_ADDRESS}
 sender.email.address=${SENDER_EMAIL_ADDRESS}
 greenoffice.email.address=${GREEN_OFFICE_EMAIL_ADDRESS}
+tgbotfeedbacks.email.address=${TG_BOT_FEEDBACKS_EMAIL_ADDRESS}
 google.clientId=${GOOGLE_CLIENT_ID}
 google.clientId.manager=${GOOGLE_CLIENT_ID_MANAGER}
 

--- a/greencity-user-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-user-chart/templates/ClusterExternalSecret.yaml
@@ -253,6 +253,10 @@ spec:
         remoteRef:
           key: GREEN-OFFICE-EMAIL-ADDRESS
 
+      - secretKey: TG-BOT-FEEDBACKS-EMAIL-ADDRESS
+        remoteRef:
+          key: TG-BOT-FEEDBACKS-EMAIL-ADDRESS
+
       - secretKey: GOOGLE-MAP-API-KEY
         remoteRef:
           key: GOOGLE-MAP-API-KEY
@@ -284,6 +288,10 @@ spec:
       - secretKey: WAY-FOR-PAY-RETURN-URL
         remoteRef:
           key: WAY-FOR-PAY-RETURN-URL
+
+      - secretKey: WAY-FOR-PAY-CONFIRM-PAGE
+        remoteRef:
+          key: WAY-FOR-PAY-CONFIRM-PAGE
 
       - secretKey: WAY-FOR-PAY-CONFIRM-PAGE
         remoteRef:

--- a/greencity-user-chart/templates/greencity-user.yaml
+++ b/greencity-user-chart/templates/greencity-user.yaml
@@ -294,6 +294,13 @@ spec:
               name: {{ .Values.externalSecret.secretName }}
               key: GREEN-OFFICE-EMAIL-ADDRESS
 
+
+        - name: TG_BOT_FEEDBACKS_EMAIL_ADDRESS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalSecret.secretName }}
+              key: TG-BOT-FEEDBACKS-EMAIL-ADDRESS
+
         - name: SIGN_IN_TOKEN
           valueFrom:
             secretKeyRef:

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -48,6 +48,7 @@ public class EmailServiceImpl implements EmailService {
     private final String clientLink;
     private final String senderEmailAddress;
     private final String greenOfficeEmailAddress;
+    private final String tgBotFeedbacksEmailAddress;
     private final MessageSource messageSource;
     private static final String PARAM_USER_ID = "&user_id=";
     private final UserRepo userRepo;
@@ -62,6 +63,7 @@ public class EmailServiceImpl implements EmailService {
         @Value("${client.address}") String clientLink,
         @Value("${sender.email.address}") String senderEmailAddress,
         @Value("${greenoffice.email.address}") String greenOfficeEmailAddress,
+        @Value("${tgbotfeedbacks.email.address}") String tgBotFeedbacksEmailAddress,
         MessageSource messageSource,
         UserRepo userRepo) {
         this.javaMailSender = javaMailSender;
@@ -70,6 +72,7 @@ public class EmailServiceImpl implements EmailService {
         this.clientLink = clientLink;
         this.senderEmailAddress = senderEmailAddress;
         this.greenOfficeEmailAddress = greenOfficeEmailAddress;
+        this.tgBotFeedbacksEmailAddress = tgBotFeedbacksEmailAddress;
         this.messageSource = messageSource;
         this.userRepo = userRepo;
     }
@@ -389,7 +392,7 @@ public class EmailServiceImpl implements EmailService {
         model.put(EmailConstants.COMMENT, dto.getComment());
 
         String template = createEmailTemplate(model, EmailConstants.TELEGRAM_FEEDBACK);
-        sendEmail(greenOfficeEmailAddress, dto.getSubject(), template);
+        sendEmail(tgBotFeedbacksEmailAddress, dto.getSubject(), template);
     }
 
     private String getClientLinkByIsUbs(boolean isUbs) {

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -90,6 +90,7 @@ class EmailServiceImplTest {
             "http://localhost:4200",
             "test@email.com",
             "test@email.com",
+            "test@email.com",
             messageSource,
             userRepo);
         when(javaMailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));


### PR DESCRIPTION
# GreenCityUser PR
## Issue Links 📋
- <a href="https://github.com/ita-social-projects/GreenCity/issues/9097">#9097</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Telegram Bot feedback emails now send to a dedicated address.

- Configuration
  - New TG Bot feedback email setting added and supported across environments; value can be provided via TG_BOT_FEEDBACKS_EMAIL_ADDRESS and sourced from deployment secrets.

- Tests
  - Tests updated to account for the additional email configuration parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->