### PR TITLE
#9079 - Added a new authority category and appropriate authority for settings management

### DIFF
--- a/dao/src/main/resources/db/changelog/logs/ch-add-authority-category-table-Popovych.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-authority-category-table-Popovych.xml
@@ -321,4 +321,21 @@
             </update>
         </rollback>
     </changeSet>
+
+    <changeSet id="add-new-authority-category-settings" author="BohdanLys">
+        <insert tableName="authority_category">
+            <column name="id" valueNumeric="10"/>
+            <column name="name_en" value="Settings"/>
+            <column name="name_uk" value="Налаштування"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="map-new-authority-to-category-settings" author="BohdanLys">
+        <update tableName="employee_authorities">
+            <column name="category_id" valueNumeric="10"/>
+            <column name="description_en" value="System settings"/>
+            <column name="description_uk" value="Налаштуванням системи"/>
+            <where>name = 'SETTINGS_MANAGEMENT'</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-Hlazova.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-Hlazova.xml
@@ -136,4 +136,11 @@
             <column name="name">TELEGRAM_MANAGEMENT</column>
         </insert>
     </changeSet>
+
+    <changeSet id="add-new-authority-settings-management" author="BohdanLys">
+        <insert tableName="employee_authorities">
+            <column name="id">35</column>
+            <column name="name">SETTINGS_MANAGEMENT</column>
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-mapping-Korzh.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-mapping-Korzh.xml
@@ -136,4 +136,11 @@
             <column name="user_id" value="2"/>
         </insert>
     </changeSet>
+
+    <changeSet id="map-settings-authority-to-user" author="BohdanLys">
+        <insert tableName="employee_authorities_mapping">
+            <column name="authority_id" value="35"/>
+            <column name="user_id" value="2"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-positions-authorities-mapping-Korzh.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-positions-authorities-mapping-Korzh.xml
@@ -365,4 +365,11 @@
                 ON CONFLICT (position_id, authorities_id) DO NOTHING;
         </sql>
     </changeSet>
+
+    <changeSet id="map-new-authority-to-super-admin" author="BohdanLys">
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">35</column>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/9079">#9079</a>

## Changed
- Added appropriate changesets for adding a new authority category and authority;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a “Settings” permission category to better organize administrative capabilities.
  - Added a new “Settings Management” permission enabling management of system settings.

- Access & Permissions
  - Granted “Settings Management” to the Super Admin role.
  - Initially assigned the permission to designated user(s) for rollout.

- Chores
  - Updated database change logs to include the new permission, category, and mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->