### PR TITLE
Bugfix #9116 added GREENCITY-UBS-ADMIN-BASE-URL to a cluster

### DIFF
--- a/greencity-user-chart/templates/ClusterExternalSecret.yaml
+++ b/greencity-user-chart/templates/ClusterExternalSecret.yaml
@@ -305,4 +305,8 @@ spec:
         remoteRef:
           key: PROFILE
 
+      - secretKey: GREENCITY-UBS-ADMIN-BASE-URL
+        remoteRef:
+          key: GREENCITY-UBS-ADMIN-BASE-URL
+
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new production secret entry (GREENCITY-UBS-ADMIN-BASE-URL) to the external secret configuration.
  * Updated the data section for production to include the key and its remote reference for secret management.
  * Affects deployment configuration only and does not change application behavior, UI, or user workflows.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->