### PR TITLE
Bugfix #9194 - Wrong logic when user resets his password

### DIFF
--- a/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/PasswordRecoveryServiceImpl.java
@@ -6,6 +6,7 @@ import greencity.entity.RestorePasswordEmail;
 import greencity.entity.User;
 import greencity.enums.UserStatus;
 import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.BadUserStatusException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserActivationEmailTokenExpiredException;
 import greencity.exception.exceptions.WrongEmailException;
@@ -57,6 +58,10 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
     public void sendPasswordRecoveryEmailTo(String email, boolean isUbs) {
         User user = userRepo.findByEmail(email)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + email));
+        if (user.getUserStatus() == UserStatus.CREATED) {
+            throw new BadUserStatusException(ErrorMessage.USER_CREATED);
+        }
+
         RestorePasswordEmail restorePasswordEmail = user.getRestorePasswordEmail();
         if (restorePasswordEmail != null) {
             throw new WrongEmailException(ErrorMessage.PASSWORD_RESTORE_LINK_ALREADY_SENT + email);

--- a/service/src/test/java/greencity/security/service/PasswordRecoveryServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/PasswordRecoveryServiceImplTest.java
@@ -10,7 +10,9 @@ import static greencity.ModelUtils.TEST_USER;
 
 import greencity.entity.RestorePasswordEmail;
 import greencity.entity.User;
+import greencity.enums.UserStatus;
 import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.BadUserStatusException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserActivationEmailTokenExpiredException;
 import greencity.exception.exceptions.WrongEmailException;
@@ -63,6 +65,16 @@ class PasswordRecoveryServiceImplTest {
         boolean isUbs = false;
         when(userRepo.findByEmail(email)).thenReturn(empty());
         assertThrows(NotFoundException.class,
+            () -> passwordRecoveryService.sendPasswordRecoveryEmailTo(email, isUbs));
+    }
+
+    @Test
+    void sendPasswordRecoveryEmailToNotVerifiedUserTest() {
+        String email = "foo";
+        boolean isUbs = false;
+        when(userRepo.findByEmail(email)).thenReturn(Optional.of(
+            User.builder().userStatus(UserStatus.CREATED).build()));
+        assertThrows(BadUserStatusException.class,
             () -> passwordRecoveryService.sendPasswordRecoveryEmailTo(email, isUbs));
     }
 


### PR DESCRIPTION
# GreenCityUser PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/9194">#9194</a>

## Changed
- Added check in reset password flow, that checks user status;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents password recovery for unverified accounts. Users must verify their email before requesting a password reset, and will now see an appropriate error message when attempting recovery too early. This clarifies the flow and reduces confusion.

* **Tests**
  * Added test coverage to ensure password recovery is blocked for unverified accounts and that the correct error is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->