### PR TITLE
Bugfix #9238 - Employee creation doesn't create user profile

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -186,7 +186,12 @@ public class SecurityConfig {
                     "/management/socialnetworkimages/get-all-remote",
                     "/management/socialnetworkimages/find",
                     "/ownSecurity/authorities/categories",
-                    "/ownSecurity/authorities/by-category")
+                    "/ownSecurity/authorities/by-category",
+                    "/user/findByUuid/external")
+                .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
+                .requestMatchers(HttpMethod.POST,
+                    "/email/sendReasonOfDeactivation",
+                    "/email/sendMessageOfActivation")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.PATCH,
                     "/user/to-do-list-items/{userToDoListItemId}",
@@ -215,8 +220,6 @@ public class SecurityConfig {
                     "/email/sendReport",
                     "/email/sendHabitNotification",
                     "/email/sendInterestingEcoNews",
-                    "/email/sendReasonOfDeactivation",
-                    "/email/sendMessageOfActivation",
                     "/management/socialnetworkimages/save-remote",
                     "/user-notification-preference/search",
                     FILES + "/single")
@@ -234,8 +237,7 @@ public class SecurityConfig {
                     "/user/roles-distribution",
                     "/user/findByEmailAdvanced",
                     "/user/isOnline",
-                    "/user/greencity/lang",
-                    "/user/findByUuid/external")
+                    "/user/greencity/lang")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.DELETE,
                     "/management/socialnetworkimages/delete",

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -495,4 +495,12 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(exceptionResponse);
     }
+
+    @ExceptionHandler({UserProfileCreationException.class})
+    public ResponseEntity<ExceptionResponse> handleUserProfileCreationException(UserProfileCreationException ex,
+        WebRequest request) {
+        log.info(ex.getMessage());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(exceptionResponse);
+    }
 }

--- a/dao/src/main/java/greencity/entity/User.java
+++ b/dao/src/main/java/greencity/entity/User.java
@@ -92,7 +92,7 @@ public class User {
     @OneToOne(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private VerifyEmail verifyEmail;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.PERSIST)
+    @OneToOne(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private RestorePasswordEmail restorePasswordEmail;
 
     @Enumerated(value = EnumType.ORDINAL)

--- a/service-api/src/main/java/greencity/exception/exceptions/UserProfileCreationException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/UserProfileCreationException.java
@@ -3,7 +3,7 @@ package greencity.exception.exceptions;
 import lombok.experimental.StandardException;
 
 /**
- * Exception thrown when user profile in external service wasn't created
+ * Exception thrown when user profile in external service wasn't created.
  *
  * @author Rostyslav Zadyraichuk
  */

--- a/service-api/src/main/java/greencity/exception/exceptions/UserProfileCreationException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/UserProfileCreationException.java
@@ -1,0 +1,12 @@
+package greencity.exception.exceptions;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Exception thrown when user profile in external service wasn't created
+ *
+ * @author Rostyslav Zadyraichuk
+ */
+@StandardException
+public class UserProfileCreationException extends RuntimeException {
+}

--- a/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
+++ b/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
@@ -44,7 +44,7 @@ public interface OwnSecurityService {
      * @param userId a value of {@link Long}
      * @throws UserProfileCreationException if user external profile wasn't created
      */
-    void createUserProfiles(Long userId);
+    void createExternalUserProfiles(Long userId);
 
     /**
      * Method that allow you sign-in user.

--- a/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
+++ b/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
@@ -3,6 +3,7 @@ package greencity.security.service;
 import greencity.dto.user.UserAdminRegistrationDto;
 import greencity.dto.user.UserManagementCreateDto;
 import greencity.enums.ProjectName;
+import greencity.exception.exceptions.UserProfileCreationException;
 import greencity.security.dto.AccessRefreshTokensDto;
 import greencity.security.dto.SuccessSignInDto;
 import greencity.security.dto.SuccessSignUpDto;
@@ -36,6 +37,14 @@ public interface OwnSecurityService {
      * @return {@link SuccessSignUpDto}
      */
     SuccessSignUpDto signUpEmployee(EmployeeSignUpDto dto, String language);
+
+    /**
+     * Method that allows you to create user UBS and GreenCity profiles.
+     *
+     * @param userId a value of {@link Long}
+     * @throws UserProfileCreationException if user external profile wasn't created
+     */
+    void createUserProfiles(Long userId);
 
     /**
      * Method that allow you sign-in user.

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -1,6 +1,8 @@
 package greencity.security.service;
 
+import greencity.client.GreenCityRemoteClient;
 import greencity.constant.ErrorMessage;
+import greencity.dto.ubs.UbsProfileCreationDto;
 import greencity.dto.user.UserAdminRegistrationDto;
 import greencity.dto.user.UserManagementCreateDto;
 import greencity.dto.user.UserVO;
@@ -20,10 +22,12 @@ import greencity.enums.UserStatus;
 import greencity.exception.exceptions.BadRefreshTokenException;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.EmailNotVerified;
+import greencity.exception.exceptions.GreenCityServiceException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.PasswordsDoNotMatchesException;
 import greencity.exception.exceptions.UserAlreadyHasPasswordException;
 import greencity.exception.exceptions.UserAlreadyRegisteredException;
+import greencity.exception.exceptions.UserProfileCreationException;
 import greencity.exception.exceptions.WrongEmailException;
 import greencity.exception.exceptions.WrongPasswordException;
 import greencity.repository.AuthorityRepo;
@@ -62,6 +66,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 
 /**
  * The class provides implementation of the {@code OwnSecurityService}.
@@ -83,6 +88,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
     private final EmailService emailService;
     private final AuthorityRepo authorityRepo;
     private final LoginAttemptService loginAttemptService;
+    private final GreenCityRemoteClient greenCityRemoteClient;
     @Value("${security.jwt.verify-email.expiration-hours}")
     private Integer expirationTime;
     @Value("${security.brute-force.block-time-minutes}")
@@ -166,6 +172,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
     /**
      * {@inheritDoc}
      */
+    @Override
     public SuccessSignUpDto signUpEmployee(EmployeeSignUpDto employeeSignUpDto, String language) {
         String password = generatePassword();
         employeeSignUpDto.setPassword(password);
@@ -183,10 +190,12 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
             .toList();
         employee.setAuthorities(authorityRepo.findAuthoritiesByPositions(positionNames));
         employee.setPositions(positionRepo.findPositionsByNames(positionNames));
+        employee.setUserStatus(UserStatus.VERIFIED);
 
         try {
             User savedUser = userRepo.save(employee);
             employee.setId(savedUser.getId());
+            createUserProfiles(savedUser.getId());
             emailService.sendCreateNewPasswordForEmployee(savedUser.getId(), savedUser.getFirstName(),
                 employee.getEmail(), savedUser.getRestorePasswordEmail().getToken(), language, dto.isUbs());
         } catch (DataIntegrityViolationException e) {
@@ -196,9 +205,24 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         return new SuccessSignUpDto(employee.getId(), employee.getName(), employee.getEmail(), true);
     }
 
-    private LocalDateTime calculateExpirationDateTime() {
-        LocalDateTime now = LocalDateTime.now();
-        return now.plusHours(this.expirationTime);
+    @Override
+    public void createUserProfiles(Long userId) {
+        User user = userRepo.findById(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId));
+
+        try {
+            Long ubsProfileId = greenCityRemoteClient.createUbsProfile(modelMapper.map(user,
+                UbsProfileCreationDto.class));
+            log.info("Ubs profile with id {} has been created for user with uuid {}.", ubsProfileId, user.getUuid());
+        } catch (WebClientRequestException | GreenCityServiceException e) {
+            userRepo.delete(user);
+            String exceptionMessage = String.format("Ubs profile has not been created for user with uuid %s.",
+                user.getUuid());
+            log.warn(exceptionMessage);
+            throw new UserProfileCreationException(exceptionMessage);
+        }
+
+        userService.createGreenCityUser(user.getId(), null);
     }
 
     /**
@@ -219,6 +243,11 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         }
 
         return createSuccessSignInResponse(user, email);
+    }
+
+    private LocalDateTime calculateExpirationDateTime() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.plusHours(this.expirationTime);
     }
 
     private UserVO validateUser(final String email) {

--- a/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/OwnSecurityServiceImpl.java
@@ -195,7 +195,7 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         try {
             User savedUser = userRepo.save(employee);
             employee.setId(savedUser.getId());
-            createUserProfiles(savedUser.getId());
+            createExternalUserProfiles(savedUser.getId());
             emailService.sendCreateNewPasswordForEmployee(savedUser.getId(), savedUser.getFirstName(),
                 employee.getEmail(), savedUser.getRestorePasswordEmail().getToken(), language, dto.isUbs());
         } catch (DataIntegrityViolationException e) {
@@ -205,8 +205,11 @@ public class OwnSecurityServiceImpl implements OwnSecurityService {
         return new SuccessSignUpDto(employee.getId(), employee.getName(), employee.getEmail(), true);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void createUserProfiles(Long userId) {
+    public void createExternalUserProfiles(Long userId) {
         User user = userRepo.findById(userId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId));
 

--- a/service/src/main/java/greencity/security/service/VerifyEmailServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/VerifyEmailServiceImpl.java
@@ -1,25 +1,19 @@
 package greencity.security.service;
 
-import greencity.client.GreenCityRemoteClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
-import greencity.dto.ubs.UbsProfileCreationDto;
 import greencity.entity.User;
 import greencity.entity.VerifyEmail;
 import greencity.enums.UserStatus;
-import greencity.exception.exceptions.GreenCityServiceException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.UserRepo;
 import greencity.security.repository.VerifyEmailRepo;
 import java.util.List;
-import greencity.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClientRequestException;
 
 /**
  * The class provides implementation of the {@code VerifyEmailService}.
@@ -31,9 +25,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 public class VerifyEmailServiceImpl implements VerifyEmailService {
     private final VerifyEmailRepo verifyEmailRepo;
     private final UserRepo userRepo;
-    private final ModelMapper modelMapper;
-    private final UserService userService;
-    private final GreenCityRemoteClient greenCityRemoteClient;
+    private final OwnSecurityService ownSecurityService;
 
     /**
      * {@inheritDoc}
@@ -42,25 +34,14 @@ public class VerifyEmailServiceImpl implements VerifyEmailService {
     public Boolean verifyByToken(Long userId, String token) {
         VerifyEmail verifyEmail = verifyEmailRepo.findByTokenAndUserId(token, userId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.VERIFICATION_TOKEN_NOT_FOUND_OR_EXPIRED));
-
         User user = verifyEmail.getUser();
-        try {
-            Long ubsProfileId = greenCityRemoteClient.createUbsProfile(modelMapper.map(user,
-                UbsProfileCreationDto.class));
-            log.info("Ubs profile with id {} has been created for user with uuid {}.", ubsProfileId, user.getUuid());
-        } catch (WebClientRequestException | GreenCityServiceException e) {
-            log.warn("Ubs profile has not been created for user with uuid {}.", user.getUuid());
-            return false;
-        }
 
+        ownSecurityService.createUserProfiles(user.getId());
         user.setUserStatus(UserStatus.VERIFIED);
-        user = userRepo.save(user);
-
-        userService.createGreenCityUser(user.getId(), null);
-
+        userRepo.save(user);
         verifyEmailRepo.deleteByTokenAndUserId(token, userId);
-        log.info("User has successfully verify the email by token {}.", token);
 
+        log.info("User has successfully verified the email by token {}.", token);
         return true;
     }
 

--- a/service/src/main/java/greencity/security/service/VerifyEmailServiceImpl.java
+++ b/service/src/main/java/greencity/security/service/VerifyEmailServiceImpl.java
@@ -36,7 +36,7 @@ public class VerifyEmailServiceImpl implements VerifyEmailService {
             .orElseThrow(() -> new NotFoundException(ErrorMessage.VERIFICATION_TOKEN_NOT_FOUND_OR_EXPIRED));
         User user = verifyEmail.getUser();
 
-        ownSecurityService.createUserProfiles(user.getId());
+        ownSecurityService.createExternalUserProfiles(user.getId());
         user.setUserStatus(UserStatus.VERIFIED);
         userRepo.save(user);
         verifyEmailRepo.deleteByTokenAndUserId(token, userId);

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -666,10 +666,8 @@ class OwnSecurityServiceImplTest {
                 new RuntimeException("Connection refused"),
                 HttpMethod.POST,
                 URI.create("http://external-service"),
-                HttpHeaders.EMPTY
-            ), "WebClientRequestException"),
+                HttpHeaders.EMPTY), "WebClientRequestException"),
             Arguments.of(new GreenCityServiceException("Green City service error"),
-                "GreenCityServiceException")
-        );
+                "GreenCityServiceException"));
     }
 }

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -3,45 +3,83 @@ package greencity.security.service;
 import greencity.ModelUtils;
 import greencity.TestConst;
 import greencity.client.CloudFlareClient;
+import greencity.client.GreenCityRemoteClient;
 import greencity.constant.ErrorMessage;
 import greencity.dto.ownsecurity.OwnSecurityVO;
 import greencity.dto.security.CloudFlareRequest;
 import greencity.dto.security.CloudFlareResponse;
+import greencity.dto.ubs.UbsProfileCreationDto;
 import greencity.dto.user.UserAdminRegistrationDto;
 import greencity.dto.user.UserManagementCreateDto;
 import greencity.dto.user.UserVO;
 import greencity.dto.verifyemail.VerifyEmailVO;
-import greencity.entity.*;
+import greencity.entity.Language;
+import greencity.entity.User;
 import greencity.enums.ProjectName;
 import greencity.enums.Role;
 import greencity.enums.UserStatus;
-import greencity.exception.exceptions.*;
+import greencity.exception.exceptions.BadRefreshTokenException;
+import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.EmailNotVerified;
+import greencity.exception.exceptions.GreenCityServiceException;
+import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.PasswordsDoNotMatchesException;
+import greencity.exception.exceptions.UserAlreadyHasPasswordException;
+import greencity.exception.exceptions.UserAlreadyRegisteredException;
+import greencity.exception.exceptions.UserProfileCreationException;
+import greencity.exception.exceptions.WrongEmailException;
+import greencity.exception.exceptions.WrongPasswordException;
 import greencity.repository.AuthorityRepo;
 import greencity.repository.PositionRepo;
 import greencity.repository.UserRepo;
-import greencity.security.dto.ownsecurity.*;
+import greencity.security.dto.ownsecurity.EmployeeSignUpDto;
+import greencity.security.dto.ownsecurity.OwnSignInDto;
+import greencity.security.dto.ownsecurity.OwnSignUpDto;
+import greencity.security.dto.ownsecurity.SetPasswordDto;
+import greencity.security.dto.ownsecurity.TestersSignInRequest;
+import greencity.security.dto.ownsecurity.UpdatePasswordDto;
 import greencity.security.jwt.JwtTool;
 import greencity.security.repository.OwnSecurityRepo;
 import greencity.security.repository.RestorePasswordEmailRepo;
 import greencity.service.EmailService;
 import greencity.service.UserService;
 import io.jsonwebtoken.ExpiredJwtException;
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.modelmapper.ModelMapper;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -83,6 +121,9 @@ class OwnSecurityServiceImplTest {
     @Mock
     CloudFlareClient cloudFlareClient;
 
+    @Mock
+    GreenCityRemoteClient greenCityRemoteClient;
+
     OwnSecurityService ownSecurityService;
 
     private UserVO verifiedUser;
@@ -97,7 +138,7 @@ class OwnSecurityServiceImplTest {
     void init() {
         ownSecurityService = new OwnSecurityServiceImpl(ownSecurityRepo, positionRepo, userService, passwordEncoder,
             jwtTool, restorePasswordEmailRepo, modelMapper, userRepo, emailService, authorityRepo,
-            loginAttemptService);
+            loginAttemptService, greenCityRemoteClient);
 
         ReflectionTestUtils.setField(ownSecurityService, "expirationTime", 1);
         ReflectionTestUtils.setField(ownSecurityService, "secretKey", "secret-key");
@@ -173,12 +214,13 @@ class OwnSecurityServiceImplTest {
         when(modelMapper.map(any(User.class), eq(UserVO.class))).thenReturn(userVO);
         when(modelMapper.map(any(EmployeeSignUpDto.class), eq(OwnSignUpDto.class))).thenReturn(ownSignUpDto);
         when(userRepo.save(any(User.class))).thenReturn(user);
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
         when(jwtTool.generateTokenKey()).thenReturn("New-token-key");
         when(jwtTool.generateTokenKeyWithCodedDate()).thenReturn("New-token-key");
 
         ownSecurityService.signUpEmployee(employeeSignUpDto, "en");
 
-        verify(modelMapper, times(2)).map(any(), any());
+        verify(modelMapper, times(3)).map(any(), any());
         verify(userRepo).save(any());
         verify(jwtTool, times(1)).generateTokenKeyWithCodedDate();
         verify(jwtTool, times(1)).generateTokenKey();
@@ -194,13 +236,14 @@ class OwnSecurityServiceImplTest {
 
         when(modelMapper.map(any(User.class), eq(UserVO.class))).thenReturn(userVO);
         when(modelMapper.map(any(EmployeeSignUpDto.class), eq(OwnSignUpDto.class))).thenReturn(ownSignUpDto);
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
         when(userRepo.save(any(User.class))).thenReturn(user);
         when(jwtTool.generateTokenKey()).thenReturn("New-token-key");
         when(jwtTool.generateTokenKeyWithCodedDate()).thenReturn("New-token-key");
 
         ownSecurityService.signUpEmployee(employeeSignUpDto, "en");
 
-        verify(modelMapper, times(2)).map(any(), any());
+        verify(modelMapper, times(3)).map(any(), any());
         verify(userRepo).save(any());
         verify(jwtTool, times(1)).generateTokenKeyWithCodedDate();
         verify(jwtTool, times(1)).generateTokenKey();
@@ -216,13 +259,14 @@ class OwnSecurityServiceImplTest {
 
         when(modelMapper.map(any(User.class), eq(UserVO.class))).thenReturn(userVO);
         when(modelMapper.map(any(EmployeeSignUpDto.class), eq(OwnSignUpDto.class))).thenReturn(ownSignUpDto);
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
         when(userRepo.save(any(User.class))).thenReturn(user);
         when(jwtTool.generateTokenKey()).thenReturn("New-token-key");
         when(jwtTool.generateTokenKeyWithCodedDate()).thenReturn("New-token-key");
 
         ownSecurityService.signUpEmployee(employeeSignUpDto, "en");
 
-        verify(modelMapper, times(2)).map(any(), any());
+        verify(modelMapper, times(3)).map(any(), any());
         verify(userRepo).save(any());
         verify(jwtTool, times(1)).generateTokenKeyWithCodedDate();
         verify(jwtTool, times(1)).generateTokenKey();
@@ -558,5 +602,74 @@ class OwnSecurityServiceImplTest {
 
         verify(userService).findByEmail(anyString());
         verify(passwordEncoder).matches(anyString(), anyString());
+    }
+
+    @Test
+    void createExternalUserProfilesTest() {
+        User user = ModelUtils.getUser();
+        UbsProfileCreationDto ubsProfileDto = ModelUtils.getUbsProfileCreationDto();
+
+        when(modelMapper.map(user, UbsProfileCreationDto.class)).thenReturn(ubsProfileDto);
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
+        when(greenCityRemoteClient.createUbsProfile(ubsProfileDto)).thenReturn(1L);
+
+        ownSecurityService.createExternalUserProfiles(user.getId());
+
+        verify(userRepo).findById(user.getId());
+        verify(modelMapper).map(user, UbsProfileCreationDto.class);
+        verify(greenCityRemoteClient).createUbsProfile(ubsProfileDto);
+        verify(userService).createGreenCityUser(user.getId(), null);
+        verify(userRepo, never()).delete(any(User.class));
+    }
+
+    @Test
+    void createExternalUserProfilesWhenUserNotFoundTest() {
+        Long userId = 999L;
+
+        when(userRepo.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+            () -> ownSecurityService.createExternalUserProfiles(userId));
+
+        verify(userRepo).findById(userId);
+        verify(greenCityRemoteClient, never()).createUbsProfile(any());
+        verify(userService, never()).createGreenCityUser(anyLong(), any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideExceptions")
+    void createExternalUserProfilesWhenServiceUnavailableTest(RuntimeException exception) throws Exception {
+        User user = ModelUtils.getUser();
+        UbsProfileCreationDto ubsProfileDto = ModelUtils.getUbsProfileCreationDto();
+
+        when(modelMapper.map(user, UbsProfileCreationDto.class)).thenReturn(ubsProfileDto);
+        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
+        when(greenCityRemoteClient.createUbsProfile(ubsProfileDto)).thenThrow(exception);
+
+        UserProfileCreationException result = assertThrows(UserProfileCreationException.class,
+            () -> ownSecurityService.createExternalUserProfiles(user.getId()));
+
+        String expectedMessage = String.format("Ubs profile has not been created for user with uuid %s.",
+            user.getUuid());
+        assertEquals(expectedMessage, result.getMessage());
+
+        verify(userRepo).findById(user.getId());
+        verify(modelMapper).map(user, UbsProfileCreationDto.class);
+        verify(greenCityRemoteClient).createUbsProfile(ubsProfileDto);
+        verify(userRepo).delete(user);
+        verify(userService, never()).createGreenCityUser(anyLong(), any());
+    }
+
+    private static Stream<Arguments> provideExceptions() {
+        return Stream.of(
+            Arguments.of(new WebClientRequestException(
+                new RuntimeException("Connection refused"),
+                HttpMethod.POST,
+                URI.create("http://external-service"),
+                HttpHeaders.EMPTY
+            ), "WebClientRequestException"),
+            Arguments.of(new GreenCityServiceException("Green City service error"),
+                "GreenCityServiceException")
+        );
     }
 }

--- a/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/OwnSecurityServiceImplTest.java
@@ -638,22 +638,23 @@ class OwnSecurityServiceImplTest {
 
     @ParameterizedTest
     @MethodSource("provideExceptions")
-    void createExternalUserProfilesWhenServiceUnavailableTest(RuntimeException exception) throws Exception {
+    void createExternalUserProfilesWhenServiceUnavailableTest(RuntimeException exception) {
         User user = ModelUtils.getUser();
+        Long userId = user.getId();
         UbsProfileCreationDto ubsProfileDto = ModelUtils.getUbsProfileCreationDto();
 
         when(modelMapper.map(user, UbsProfileCreationDto.class)).thenReturn(ubsProfileDto);
-        when(userRepo.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
         when(greenCityRemoteClient.createUbsProfile(ubsProfileDto)).thenThrow(exception);
 
         UserProfileCreationException result = assertThrows(UserProfileCreationException.class,
-            () -> ownSecurityService.createExternalUserProfiles(user.getId()));
+            () -> ownSecurityService.createExternalUserProfiles(userId));
 
         String expectedMessage = String.format("Ubs profile has not been created for user with uuid %s.",
             user.getUuid());
         assertEquals(expectedMessage, result.getMessage());
 
-        verify(userRepo).findById(user.getId());
+        verify(userRepo).findById(userId);
         verify(modelMapper).map(user, UbsProfileCreationDto.class);
         verify(greenCityRemoteClient).createUbsProfile(ubsProfileDto);
         verify(userRepo).delete(user);

--- a/service/src/test/java/greencity/security/service/VerifyEmailServiceImplTest.java
+++ b/service/src/test/java/greencity/security/service/VerifyEmailServiceImplTest.java
@@ -1,35 +1,29 @@
 package greencity.security.service;
 
-import greencity.client.GreenCityRemoteClient;
 import greencity.constant.ErrorMessage;
-import greencity.dto.ubs.UbsProfileCreationDto;
 import greencity.entity.User;
 import greencity.entity.VerifyEmail;
 import greencity.enums.UserStatus;
-import greencity.exception.exceptions.GreenCityServiceException;
 import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.UserProfileCreationException;
 import greencity.repository.UserRepo;
 import greencity.security.repository.VerifyEmailRepo;
 import java.util.List;
 import java.util.Optional;
 
-import greencity.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.modelmapper.ModelMapper;
-import static greencity.ModelUtils.getUbsProfileCreationDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doNothing;
 
 @ExtendWith(MockitoExtension.class)
 class VerifyEmailServiceImplTest {
@@ -37,16 +31,10 @@ class VerifyEmailServiceImplTest {
     VerifyEmailRepo verifyEmailRepo;
 
     @Mock
-    ModelMapper modelMapper;
-
-    @Mock
     UserRepo userRepo;
 
     @Mock
-    GreenCityRemoteClient greenCityRemoteClient;
-
-    @Mock
-    UserService userService;
+    OwnSecurityService ownSecurityService;
 
     User user = User.builder()
         .id(1L)
@@ -65,18 +53,13 @@ class VerifyEmailServiceImplTest {
 
     @Test
     void verifyByTokenNotExpiredTokenTest() {
-        UbsProfileCreationDto ubsProfile = getUbsProfileCreationDto();
-
         when(verifyEmailRepo.findByTokenAndUserId("token", 1L)).thenReturn(Optional.of(verifyEmail));
-        when(modelMapper.map(user, UbsProfileCreationDto.class)).thenReturn(ubsProfile);
-        doReturn(1L).when(greenCityRemoteClient).createUbsProfile(ubsProfile);
         when(userRepo.save(any(User.class))).thenReturn(user);
-        doNothing().when(userService).createGreenCityUser(user.getId(), null);
 
         verifyEmailService.verifyByToken(1L, "token");
 
         verify(verifyEmailRepo).deleteByTokenAndUserId("token", 1L);
-        verify(greenCityRemoteClient).createUbsProfile(ubsProfile);
+        verify(ownSecurityService).createExternalUserProfiles(user.getId());
     }
 
     @Test
@@ -84,21 +67,19 @@ class VerifyEmailServiceImplTest {
         String exceptionMessage = "exception message";
         String token = "token";
         Long userId = 1L;
-        UbsProfileCreationDto ubsProfile = getUbsProfileCreationDto();
-        boolean expectedResult = false;
         User mockUser = mock(User.class);
         VerifyEmail mockVerifyEmail = mock(VerifyEmail.class);
 
         when(verifyEmailRepo.findByTokenAndUserId(token, userId)).thenReturn(Optional.of(mockVerifyEmail));
         when(mockVerifyEmail.getUser()).thenReturn(mockUser);
-        when(modelMapper.map(mockUser, UbsProfileCreationDto.class)).thenReturn(ubsProfile);
-        when(greenCityRemoteClient.createUbsProfile(ubsProfile)).thenThrow(
-            new GreenCityServiceException(exceptionMessage));
+        when(mockUser.getId()).thenReturn(userId);
+        doThrow(new UserProfileCreationException(exceptionMessage))
+            .when(ownSecurityService).createExternalUserProfiles(userId);
 
-        boolean actualResult = verifyEmailService.verifyByToken(1L, "token");
+        assertThrows(UserProfileCreationException.class,
+            () -> verifyEmailService.verifyByToken(userId, "token"));
 
-        assertEquals(expectedResult, actualResult);
-        verify(greenCityRemoteClient).createUbsProfile(ubsProfile);
+        verify(ownSecurityService).createExternalUserProfiles(userId);
         verify(mockUser, never()).setUserStatus(UserStatus.VERIFIED);
         verify(userRepo, never()).save(any(User.class));
         verify(verifyEmailRepo, never()).deleteByTokenAndUserId(token, userId);
@@ -110,9 +91,8 @@ class VerifyEmailServiceImplTest {
 
         when(verifyEmailRepo.findByTokenAndUserId("token", 1L)).thenReturn(Optional.empty());
 
-        NotFoundException exception = assertThrows(NotFoundException.class, () -> {
-            verifyEmailService.verifyByToken(1L, "token");
-        });
+        NotFoundException exception = assertThrows(NotFoundException.class,
+            () -> verifyEmailService.verifyByToken(1L, "token"));
 
         assertEquals(expectedExceptionMessage, exception.getMessage());
     }


### PR DESCRIPTION
## Changed:
- moved user profile creation in external services to separate method;
- added user profile creation logic to employee sign up flow;
- fixed restrictions for employees while deactivating/activating other employees;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External user profiles are created during account setup/employee signup and verification flows.

* **Bug Fixes**
  * Improved error handling for profile-creation failures (now surfaced as service-unavailable responses) and automatic cleanup on failure.
  * Adjusted access rules for certain account/email endpoints.

* **Tests**
  * Expanded coverage for external profile creation, verification, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->