### PR TITLE
Update default permissions for Admin and Super Admin positions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-slim as runner
+FROM eclipse-temurin:21 as runner
 WORKDIR runner
 COPY **/target/app.jar runner/
 CMD java -jar runner/app.jar

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-positions-authorities-mapping-Korzh.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-positions-authorities-mapping-Korzh.xml
@@ -372,4 +372,60 @@
             <column name="authorities_id">35</column>
         </insert>
     </changeSet>
+
+    <changeSet id="update-admin-authorities-Zadyraichuk" author="Rostyslav Zadyraichuk">
+        <delete tableName="positions_authorities_mapping">
+            <where>position_id=7 AND authorities_id=19</where>
+        </delete>
+        <delete tableName="positions_authorities_mapping">
+            <where>position_id=7 AND authorities_id=28</where>
+        </delete>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">7</column>
+            <column name="authorities_id">35</column>
+        </insert>
+    </changeSet>
+
+    <changeSet id="update-super-admin-authorities-Zadyraichuk" author="Rostyslav Zadyraichuk">
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">17</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">18</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">19</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">23</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">29</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">30</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">31</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">32</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">33</column>
+        </insert>
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">6</column>
+            <column name="authorities_id">34</column>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Changed:

- removed next authorities for Admin position (related to task [#9233](https://github.com/ita-social-projects/GreenCity/issues/9233)):
  - Create a receiving station;
  - Create a pricing card;
- added new authority to Admin position:
  - System settings;
- added authorities for Super Admin position:
  - Create a location;
  - Create a courier;
  - Create a receiving station;
  - Delete a location;
  - Delete/Deactivate a courier;
  - Delete/Deactivate a receiving station;
  - See all agreements;
  - Create an agreement;
  - Delete an agreement;
  - Manage Telegram bots;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated permission mappings that could cause repeated database updates and conflicts, restoring data integrity for admin roles.

* **Chores**
  * Updated runtime base image used for the application build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->