### PR TITLE
Fix/9271 empty positions and authorities

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -38,4 +38,5 @@
     <include file="db/changelog/logs/ch-update-users-remove-profile_picture-column-Zadyraichuk.xml"/>
     <include file="db/changelog/logs/ch-update-users-change-user-status-column-Zadyraichuk.xml"/>
     <include file="db/changelog/logs/ch-drop-deactivation_reason-table-Zadyraichuk.xml"/>
+    <include file="db/changelog/logs/ch-update-positions-names-Rakuta.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -39,4 +39,5 @@
     <include file="db/changelog/logs/ch-update-users-change-user-status-column-Zadyraichuk.xml"/>
     <include file="db/changelog/logs/ch-drop-deactivation_reason-table-Zadyraichuk.xml"/>
     <include file="db/changelog/logs/ch-update-positions-names-Rakuta.xml"/>
+    <include file="db/changelog/logs/ch-insert-into-employee-authority-mapping-Rakuta.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-mapping-Rakuta.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-authority-mapping-Rakuta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="insert-new-authority-for-manager" author="AnastasiaRakuta">
+        <insert tableName="positions_authorities_mapping">
+            <column name="position_id">2</column>
+            <column name="authorities_id">34</column>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-update-positions-names-Rakuta.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-positions-names-Rakuta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="rename-positions-names" author="AnastasiaRakuta">
+        <update tableName="positions">
+            <column name="name_uk" value="Менеджер"/>
+            <where>name_uk = 'Менеджер обдзвону'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_en" value="Manager"/>
+            <where>name_en ='Call Manager'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
# GreenCityUser PR
## Issue Link 📋
[#9271](https://github.com/ita-social-projects/GreenCity/issues/9271)

## Changed
- Renamed Manager in the positions table to ensure consistency between GreenCityUser and GreenCityUBS. The system now correctly identifies the Manager role and assigns the default authorities automatically.
- Added Telegram management authority for Manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated position names for consistency in English and Ukrainian (e.g., "Call Manager" → "Manager").
  * Added a new permission mapping to grant an additional authority to manager roles.
  * Applied database migration entries to ensure the above updates are executed during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->