### PR TITLE
add actuator endpoints to read metrics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       
       - name: Test Reporter
         #v1.5.0
-        uses: dorny/test-reporter@0d00bb1
+        uses: dorny/test-reporter@0d00bb14cb0cc2c9b8985df6e81dd333188224e1
 
         if: success() || failure()
         with:
@@ -72,14 +72,14 @@ jobs:
 
       - name: Docker Login
         #v2.0.0
-        uses: docker/login-action@49ed152
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker images
         #v3.0.0
-        uses: docker/build-push-action@e551b19
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
         with:
           context: .
           file: Dockerfile
@@ -106,7 +106,7 @@ jobs:
       - name: Deploy 🚀
         if: ${{ github.event_name == 'push' }}
         #v3.7.1
-        uses: JamesIves/github-pages-deploy-action@132898c
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_USER }}
         run: |
           git fetch --unshallow
-          mvn clean install verify sonar:sonar \
+          mvn clean install sonar:sonar \
             -Dsonar.projectKey=ita-social-projects-green-city-user \
             -Dsonar.organization=ita-social-projects \
             -Dsonar.host.url=https://sonarcloud.io \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,9 @@ concurrency: Testing
 on:
   # Triggers the workflow on push or pull request events but only for the dev branch
   push:
-    branches: [ dev ]
+    branches: [ dev, prod ]
   pull_request:
-    branches: [ dev ]
+    branches: [ dev, prod ]
   workflow_dispatch:
 
 env:
@@ -55,7 +55,7 @@ jobs:
         if: success() || failure()
         with:
           name: Tests Report
-          path: ${{ env.userRepoName }}/target/surefire-reports/*.xml
+          path: '**/target/surefire-reports/*.xml'
           reporter: java-junit
       
       - name: Rename user jar to app

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI/CD GreenCityUser
 concurrency: Testing
 
 on:
-  # Triggers the workflow on push or pull request events but only for the dev branch
+  # Triggers the workflow on push or pull request events for dev and prod
   push:
     branches: [ dev, prod ]
   pull_request:
@@ -55,7 +55,9 @@ jobs:
         # Checks-out your greencity.repository under $GITHUB_WORKSPACE, so your job can access it
       
       - name: Test Reporter
-        uses: dorny/test-reporter@v1.5.0
+        #v1.5.0
+        uses: dorny/test-reporter@0d00bb1
+
         if: success() || failure()
         with:
           name: Tests Report
@@ -69,13 +71,15 @@ jobs:
         run: echo "GITHUB_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Docker Login
-        uses: docker/login-action@v2.0.0
+        #v2.0.0
+        uses: docker/login-action@49ed152
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v3.0.0
+        #v3.0.0
+        uses: docker/build-push-action@e551b19
         with:
           context: .
           file: Dockerfile
@@ -101,7 +105,8 @@ jobs:
 
       - name: Deploy 🚀
         if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        #v3.7.1
+        uses: JamesIves/github-pages-deploy-action@132898c
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_USER }}
         run: |
           git fetch --unshallow
-          mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=ita-social-projects-green-city-user -Dsonar.organization=ita-social-projects -Dsonar.host.url=https://sonarcloud.io -Dsonar.sources='src/main/java/greencity' -Dsonar.binaries=target/classes -Dsonar.dynamicAnalysis=reuseReports -Dsonar.coverage.exclusions=**/config/*,**/dto/security/*,**/enums/*
+          mvn clean install verify sonar:sonar \
+            -Dsonar.projectKey=ita-social-projects-green-city-user \
+            -Dsonar.organization=ita-social-projects \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.coverage.exclusions=**/config/*,**/dto/security/*,**/enums/*
         # Checks-out your greencity.repository under $GITHUB_WORKSPACE, so your job can access it
       
       - name: Test Reporter

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -237,6 +237,15 @@
             <groupId>com.azure.spring</groupId>
             <artifactId>spring-cloud-azure-starter-keyvault-secrets</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -133,6 +133,7 @@ public class SecurityConfig {
                     "/api/testers/sign-in")
                 .permitAll()
                 .requestMatchers(HttpMethod.GET, "/check-auth").permitAll()
+                .requestMatchers("/actuator/**").hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.GET,
                     "/user/to-do-list-items/habits/{habitId}/to-do-list",
                     "/user/{userId}/{habitId}/custom-to-do-list-items/available",

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -100,6 +100,7 @@ public class SecurityConfig {
                 .requestMatchers("/static/css/**", "/static/img/**").permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/error").permitAll()
+                .requestMatchers("/actuator/prometheus").permitAll()
                 .requestMatchers(
                     "/v2/api-docs/**",
                     "/v3/api-docs/**",

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -6,6 +6,9 @@ spring.cloud.azure.credential.client-id=${AZURE_CLIENT_ID}
 spring.cloud.azure.credential.client-secret=${AZURE_SECRET_ID}
 spring.cloud.azure.profile.tenant-id=${AZURE_TENANT_ID}
 
+# Actuator endpoints
+management.endpoints.web.exposure.include=health, info, metrics, prometheus
+
 # Datasource
 spring.datasource.url=${DATASOURCE_URL}
 spring.datasource.username=${DATASOURCE_USERNAME}

--- a/greencity-user-chart/templates/ingress-user.yaml
+++ b/greencity-user-chart/templates/ingress-user.yaml
@@ -5,10 +5,15 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://www.greencity.cx.ua"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_uri ~* "^/actuator") {
+        return 403;
+      }
 spec:
   tls:
   - hosts:

--- a/greencity-user-chart/templates/ingress-user.yaml
+++ b/greencity-user-chart/templates/ingress-user.yaml
@@ -5,15 +5,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://www.greencity.cx.ua"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* "^/actuator") {
-        return 403;
-      }
 spec:
   tls:
   - hosts:
@@ -23,6 +18,15 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
+        # fake service to block /actuator/prometheus and allow all other endpoint
+        - path: /actuator/prometheus
+          pathType: Exact
+          backend:
+            service:
+              name: actuator-prometheus-blocker
+              port:
+                number: 80
+
       - path: /
         pathType: Prefix
         backend:

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,7 @@
                 </executions>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
-                    <excludes>
-                        <exclude>**/generated-sources/annotations/**</exclude>
-                    </excludes>
+                    <excludes>**/generated-sources/annotations/**</excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
                 </executions>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
+                    <excludes>
+                        <exclude>**/generated-sources/annotations/**</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,18 @@
         <maven.compiler.target>21</maven.compiler.target>
         <checkstyle-maven-plugin.version>3.3.1</checkstyle-maven-plugin.version>
         <org.eclipse.jgit.version>7.1.0.202411261347-r</org.eclipse.jgit.version>
-        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-        <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
-        <sonar.language>java</sonar.language>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            **/target/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>5.5.0.6356</version>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,6 @@
                 </executions>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
-                    <excludes>**/generated-sources/annotations/**</excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Issue
[8077](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=95640281&issue=ita-social-projects%7CGreenCity%7C8077)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Operations**
  * Enabled Actuator endpoints (health, info, metrics, prometheus) and added Prometheus metrics support.
  * Prometheus endpoint allowed without auth; other actuator endpoints restricted to admins.
  * Ingress updated to block direct public access to the Prometheus endpoint.
  * Added runtime Prometheus registry and Actuator dependencies.

* **Chores**
  * CI workflow triggers expanded; actions and Docker steps pinned to specific commits.
  * Sonar/coverage reporting configuration consolidated and plugin updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->