### PR TITLE
Bugfix #8972 changed findUserLanguageByUuid security rule

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -159,6 +159,7 @@ public class SecurityConfig {
                     EXPORT_SETTINGS_LINKS)
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.POST,
+                    "/email/sendReasonOfDeactivation",
                     FILES)
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR)
                 .requestMatchers(HttpMethod.POST, USER_LINK,
@@ -190,7 +191,6 @@ public class SecurityConfig {
                     "/user/findByUuid/external")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.POST,
-                    "/email/sendReasonOfDeactivation",
                     "/email/sendMessageOfActivation")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.PATCH,

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -153,6 +153,7 @@ public class SecurityConfig {
                     "/ownSecurity/password-status",
                     "/user/emailNotifications",
                     "/lang",
+                    "/user/findUserLanguageByUuid",
                     "/lang/**",
                     LOGS_LINKS,
                     EXPORT_SETTINGS_LINKS)
@@ -179,7 +180,6 @@ public class SecurityConfig {
                     "/user/authorities")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
-                    "/user/findUserLanguageByUuid",
                     "/user/get-all-authorities",
                     "/user/get-positions-authorities",
                     "/user/authorities/grouped-by-categories",

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -482,6 +482,22 @@ public class GreenCityRemoteClient {
             .block();
     }
 
+    /**
+     * Retrieves a user status from the UBS external service by a given user.
+     *
+     * @param email the user email for which to retrieve the status.
+     * @return the external service user status.
+     */
+    public ServiceUserStatus getUbsUserStatusByEmail(String email) {
+        return greenCityUbsWebClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/ubs/userProfile/user/status/by_email")
+                        .queryParam("email", email)
+                        .build())
+                .retrieve()
+                .bodyToMono(ServiceUserStatus.class)
+                .block();
+    }
+
     private BodyInserters.MultipartInserter multipartInserter(MultipartFile... multipartFiles) {
         MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
 

--- a/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/GreenCityRemoteClient.java
@@ -490,12 +490,12 @@ public class GreenCityRemoteClient {
      */
     public ServiceUserStatus getUbsUserStatusByEmail(String email) {
         return greenCityUbsWebClient.get()
-                .uri(uriBuilder -> uriBuilder.path("/ubs/userProfile/user/status/by_email")
-                        .queryParam("email", email)
-                        .build())
-                .retrieve()
-                .bodyToMono(ServiceUserStatus.class)
-                .block();
+            .uri(uriBuilder -> uriBuilder.path("/ubs/userProfile/user/status/by_email")
+                .queryParam("email", email)
+                .build())
+            .retrieve()
+            .bodyToMono(ServiceUserStatus.class)
+            .block();
     }
 
     private BodyInserters.MultipartInserter multipartInserter(MultipartFile... multipartFiles) {

--- a/service/src/main/java/greencity/service/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/UserServiceImpl.java
@@ -972,7 +972,7 @@ public class UserServiceImpl implements UserService {
         ServiceUserStatus externalStatus;
         switch (projectName) {
             case GREENCITY -> externalStatus = greenCityRemoteClient.getGreenCityUserStatus(user.getEmail());
-            case PICKUP -> externalStatus = greenCityRemoteClient.getUbsUserStatus(user.getUuid());
+            case PICKUP -> externalStatus = greenCityRemoteClient.getUbsUserStatusByEmail(user.getEmail());
             default -> throw new IllegalArgumentException("Unknown project name: " + projectName);
         }
 

--- a/service/src/test/java/greencity/service/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UserServiceImplTest.java
@@ -1535,7 +1535,7 @@ class UserServiceImplTest {
         testUser.setUserStatus(UserStatus.VERIFIED);
         ServiceUserStatus serviceStatus = ServiceUserStatus.valueOf(status);
 
-        when(greenCityRemoteClient.getUbsUserStatus(any())).thenReturn(serviceStatus);
+        when(greenCityRemoteClient.getUbsUserStatusByEmail(any())).thenReturn(serviceStatus);
 
         assertThrows(BadUserStatusException.class, () -> userService.verifyUserStatus(testUser, ProjectName.PICKUP));
     }


### PR DESCRIPTION
# GreenCityUser PR
## Issue Link 📋
[#8972](https://github.com/ita-social-projects/GreenCity/issues/8972)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted access control so user-language retrieval and deactivation-reason email endpoints are now governed by the earlier role-based rules and consistently available to authorized roles (USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE).
* **New Feature / Behavior**
  * PICKUP project user status lookup now uses an email-based lookup when querying the external service, improving compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->